### PR TITLE
Feature/ptypes tableview

### DIFF
--- a/src/pymodaq_gui/examples/parameter_ex.py
+++ b/src/pymodaq_gui/examples/parameter_ex.py
@@ -109,7 +109,7 @@ class ParameterEx(ParameterManager):
                     ' pymodaq.utils.scanner module'},
             {'title': 'Table view', 'name': 'tabular_table_multitypes', 'type': 'table_view',
              'delegate': [table.BooleanDelegate,table.SpinBoxDelegate,table.SpinBoxDelegate], 'menu': True,
-             'value': table.TableModel([[True, 0.2, 0.3]], ['value1', 'value2', 'value3']),
+             'value': table.TableModel([[True, 0.2, 0.3]], ['Bool', 'Spinbox1', 'Spinbox2']),
              'tip': 'Possibility to alternate between different delegate'},                       
         ]},  # The advantage of the Table model lies in its modularity for concrete examples see the
         # TableModelTabular and the TableModelSequential custom models in the pymodaq.utils.scanner module

--- a/src/pymodaq_gui/examples/parameter_ex.py
+++ b/src/pymodaq_gui/examples/parameter_ex.py
@@ -102,14 +102,14 @@ class ParameterEx(ParameterManager):
             {'title': 'Table widget', 'name': 'tablewidget', 'type': 'table', 'value':
                 OrderedDict(key1='data1', key2=24), 'header': ['keys', 'limits'], 'height': 100},
             {'title': 'Table view', 'name': 'tabular_table', 'type': 'table_view',
-             'delegate': table.SpinBoxDelegate, 'menu': True,
-             'value': table.TableModel([[0.1, 0.2, 0.3]], ['value1', 'value2', 'value3']),
+             'delegate': table.BooleanDelegate, 'menu': True,
+             'value': table.TableModel([[True, 0.2, 0.3]], ['value1', 'value2', 'value3']),
              'tip': 'The advantage of the Table model lies in its modularity.\n For concrete examples see the'
                     'TableModelTabular and the TableModelSequential custom models in the'
                     ' pymodaq.utils.scanner module'},
             {'title': 'Table view', 'name': 'tabular_table_multitypes', 'type': 'table_view',
-             'delegate': [table.BooleanDelegate,table.SpinBoxDelegate,table.SpinBoxDelegate], 'menu': True,
-             'value': table.TableModel([[True, 0.2, 0.3]], ['Bool', 'Spinbox1', 'Spinbox2']),
+             'delegate': [None,table.BooleanDelegate,None,table.SpinBoxDelegate,], 'menu': True,
+             'value': table.TableModel([[True, False,0.1,0.1]], ['Bool_Standard', 'Bool_Delegate', 'Spinbox_standard', 'Spinbox_delegate']),
              'tip': 'Possibility to alternate between different delegate'},                       
         ]},  # The advantage of the Table model lies in its modularity for concrete examples see the
         # TableModelTabular and the TableModelSequential custom models in the pymodaq.utils.scanner module

--- a/src/pymodaq_gui/examples/parameter_ex.py
+++ b/src/pymodaq_gui/examples/parameter_ex.py
@@ -107,6 +107,10 @@ class ParameterEx(ParameterManager):
              'tip': 'The advantage of the Table model lies in its modularity.\n For concrete examples see the'
                     'TableModelTabular and the TableModelSequential custom models in the'
                     ' pymodaq.utils.scanner module'},
+            {'title': 'Table view', 'name': 'tabular_table_multitypes', 'type': 'table_view',
+             'delegate': [table.BooleanDelegate,table.SpinBoxDelegate,table.SpinBoxDelegate], 'menu': True,
+             'value': table.TableModel([[True, 0.2, 0.3]], ['value1', 'value2', 'value3']),
+             'tip': 'Possibility to alternate between different delegate'},                       
         ]},  # The advantage of the Table model lies in its modularity for concrete examples see the
         # TableModelTabular and the TableModelSequential custom models in the pymodaq.utils.scanner module
     ]

--- a/src/pymodaq_gui/parameter/pymodaq_ptypes/tableview.py
+++ b/src/pymodaq_gui/parameter/pymodaq_ptypes/tableview.py
@@ -123,13 +123,16 @@ class TableViewParameterItem(WidgetParameterItem):
         ParameterItem.optsChanged(self, param, opts)
 
         if 'delegate' in opts:
-            if hasattr(opts['delegate'],"__len__"): #Testing if an array or a single input is given
-                for col,delegate in enumerate(opts['delegate']): #If array, associate each column with its associated type
-                    styledItemDelegate = QtWidgets.QStyledItemDelegate()
-                    styledItemDelegate.setItemEditorFactory(delegate())
-                    self.widget.setItemDelegateForColumn(col,QtWidgets.QStyledItemDelegate().setItemEditorFactory(delegate()))
-            else:
-                styledItemDelegate = QtWidgets.QStyledItemDelegate() #If single input, associate all columns to the given type
+            if hasattr(opts['delegate'],"__len__"):              #Testing if an array or a single input is given                
+                delegates = []
+                for col,delegate in enumerate(opts['delegate']): #If array, associate each column with its associated type                    
+                    delegates.append(QtWidgets.QStyledItemDelegate(self.widget))
+                    if delegate is not None:
+                        delegates[col].setItemEditorFactory(delegate())
+                    self.widget.setItemDelegateForColumn(col,delegates[col])
+
+            else:                                                #If single input, associate all columns to the given type
+                styledItemDelegate = QtWidgets.QStyledItemDelegate(self.widget) 
                 styledItemDelegate.setItemEditorFactory(opts['delegate']())
                 self.widget.setItemDelegate(styledItemDelegate)   
 

--- a/src/pymodaq_gui/parameter/pymodaq_ptypes/tableview.py
+++ b/src/pymodaq_gui/parameter/pymodaq_ptypes/tableview.py
@@ -123,9 +123,15 @@ class TableViewParameterItem(WidgetParameterItem):
         ParameterItem.optsChanged(self, param, opts)
 
         if 'delegate' in opts:
-            styledItemDelegate = QtWidgets.QStyledItemDelegate()
-            styledItemDelegate.setItemEditorFactory(opts['delegate']())
-            self.widget.setItemDelegate(styledItemDelegate)
+            if hasattr(opts['delegate'],"__len__"): #Testing if an array or a single input is given
+                for col,delegate in enumerate(opts['delegate']): #If array, associate each column with its associated type
+                    styledItemDelegate = QtWidgets.QStyledItemDelegate()
+                    styledItemDelegate.setItemEditorFactory(delegate())
+                    self.widget.setItemDelegateForColumn(col,QtWidgets.QStyledItemDelegate().setItemEditorFactory(delegate()))
+            else:
+                styledItemDelegate = QtWidgets.QStyledItemDelegate() #If single input, associate all columns to the given type
+                styledItemDelegate.setItemEditorFactory(opts['delegate']())
+                self.widget.setItemDelegate(styledItemDelegate)   
 
         if 'menu' in opts:
             self.widget.setmenu(opts['menu'])

--- a/tests/parameter_test/param_ptypes_test.py
+++ b/tests/parameter_test/param_ptypes_test.py
@@ -88,3 +88,22 @@ class TestItemSelect:
             listwidget.select_item(listwidget.item(2), True)
             assert settings.value() == dict(all_items=['item1', 'item2', 'item3', ],
                                             selected=['item1', 'item3'])
+            
+
+class TestTableView:
+
+    def test_isSelected_setValue(self, init_ParameterTree):
+            import pymodaq_gui.utils.widgets.table as table
+
+            params = {'title': 'Table view', 'name': 'tabular_table_multitypes', 'type': 'table_view',
+             'delegate': [table.BooleanDelegate,table.SpinBoxDelegate,table.SpinBoxDelegate], 'menu': True,
+             'value': table.TableModel([[True, 0.2, 0.3]], ['value1', 'value2', 'value3']),
+             'tip': 'Possibility to alternate between different delegate'}
+            tree = init_ParameterTree
+            settings = Parameter.create(**params)
+            tree.setParameters(settings, showTop=False)
+            assert settings.value().get_data_all() == [[True, 0.2, 0.3]]                    
+            # Keeping selection order + erase non existing items
+            settings.setValue(table.TableModel([[True, 0.2, 0.3],[False, 1.5, 2.6]], ['value1', 'value2', 'value3']))
+            assert settings.value().get_data_all() == [[True, 0.2, 0.3],[False, 1.5, 2.6]]
+            

--- a/tests/parameter_test/param_ptypes_test.py
+++ b/tests/parameter_test/param_ptypes_test.py
@@ -96,14 +96,14 @@ class TestTableView:
             import pymodaq_gui.utils.widgets.table as table
 
             params = {'title': 'Table view', 'name': 'tabular_table_multitypes', 'type': 'table_view',
-             'delegate': [table.BooleanDelegate,table.SpinBoxDelegate,table.SpinBoxDelegate], 'menu': True,
-             'value': table.TableModel([[True, 0.2, 0.3]], ['value1', 'value2', 'value3']),
-             'tip': 'Possibility to alternate between different delegate'}
+             'delegate': [None,table.BooleanDelegate,None,table.SpinBoxDelegate,], 'menu': True,
+             'value': table.TableModel([[True, False,0.15,0.10]], ['Bool_Standard', 'Bool_Delegate', 'Spinbox_standard', 'Spinbox_delegate']),
+             'tip': 'Possibility to alternate between different delegate'}  
             tree = init_ParameterTree
             settings = Parameter.create(**params)
             tree.setParameters(settings, showTop=False)
-            assert settings.value().get_data_all() == [[True, 0.2, 0.3]]                    
+            assert settings.value().get_data_all() == [[True, False,0.15,0.10]]                 
             # Keeping selection order + erase non existing items
-            settings.setValue(table.TableModel([[True, 0.2, 0.3],[False, 1.5, 2.6]], ['value1', 'value2', 'value3']))
-            assert settings.value().get_data_all() == [[True, 0.2, 0.3],[False, 1.5, 2.6]]
+            settings.setValue(table.TableModel([[False, True,0.25,0.20],[True, False,0.42,0.40]], ['Bool_Standard', 'Bool_Delegate', 'Spinbox_standard', 'Spinbox_delegate']))
+            assert settings.value().get_data_all() == [[False, True,0.25,0.20],[True, False,0.42,0.40]]
             


### PR DESCRIPTION
Patch for tableview used as a parameter item

It now allows the user to specify for each column the delegates during a parameter item initialization such as

```
 {'title': 'Table view', 'name': 'tabular_table_multitypes', 'type': 'table_view',
             'delegate': [None,table.BooleanDelegate,None,table.SpinBoxDelegate,], 'menu': True,
             'value': table.TableModel([[True, False,0.1,0.1]], ['Bool_Standard', 'Bool_Delegate', 'Spinbox_standard', 'Spinbox_delegate']),
             'tip': 'Possibility to alternate between different delegate'},                       
        ]},
```

None type is equivalent to standard behavior, here `QtWidgets.QStyledItemDelegate()`