### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/Testbase.yml
+++ b/.github/workflows/Testbase.yml
@@ -18,9 +18,9 @@ jobs:
       QT_DEBUG_PLUGINS: 1
     steps:
       - name: Set up Python ${{ inputs.python }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.2.0
       - name: Install dependencies
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5.2.0
         with:
           python-version: ${{ inputs.python }}
       - name: Install package
@@ -43,7 +43,7 @@ jobs:
         run: |
           pytest --cov=pymodaq --cov-report=xml -n auto
       - name: Upload coverage to codecov.io
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4.6.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml

--- a/.github/workflows/Testbase_win.yml
+++ b/.github/workflows/Testbase_win.yml
@@ -18,9 +18,9 @@ jobs:
       QT_DEBUG_PLUGINS: 1
     steps:
       - name: Set up Python ${{ inputs.python }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.2.0
       - name: Install dependencies
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5.2.0
         with:
           python-version: ${{ inputs.python }}
       - name: Install package
@@ -38,7 +38,7 @@ jobs:
         run: |
           pytest --cov=pymodaq --cov-report=xml -n auto
       - name: Upload coverage to codecov.io
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4.6.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
           
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.2.0
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5.2.0
       with:
         python-version: '3.11'
     - name: Install dependencies

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v4.6.0](https://github.com/codecov/codecov-action/releases/tag/v4.6.0)** on 2024-10-01T14:53:02Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.0](https://github.com/actions/checkout/releases/tag/v4.2.0)** on 2024-09-25T17:52:55Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v5.2.0](https://github.com/actions/setup-python/releases/tag/v5.2.0)** on 2024-08-29T13:57:38Z
