### PR TITLE
Fix bugs in late Qt version for itemselect parameteritem

### DIFF
--- a/src/pymodaq_gui/parameter/pymodaq_ptypes/itemselect.py
+++ b/src/pymodaq_gui/parameter/pymodaq_ptypes/itemselect.py
@@ -54,7 +54,7 @@ class ItemSelect(QtWidgets.QListWidget):
             Function to select item. The selection depends if the item uses checkbox or not.
         """        
         if self.hasCheckbox:
-            item.setCheckState(int(2*bool(not item.checkState())))
+            item.setCheckState(QtCore.Qt.CheckState(int(2*bool(not item.checkState().value))))
             
 
     def get_value(self):
@@ -71,7 +71,7 @@ class ItemSelect(QtWidgets.QListWidget):
             # Clean up list with non existing entries      
             [self.selItems.remove(item) for item in self.selItems if item not in allitems]        
             for item in self.all_items():
-                if item.checkState() != 0: # Item is selected
+                if item.checkState() != QtCore.Qt.CheckState(0): # Item is selected
                     if item.text() not in self.selItems: # if item not in list then add it
                         self.selItems.append(item.text())
                 else: # Item is not selected
@@ -101,7 +101,7 @@ class ItemSelect(QtWidgets.QListWidget):
             Function to select item. The selection depends if the item uses checkbox or not.
         """        
         if self.hasCheckbox:
-            item.setCheckState(int(2*doSelect))  # 2=QtCore.Qt.Checked, 0=QtCore.Qt.Unchecked
+            item.setCheckState(QtCore.Qt.CheckState(int(2*doSelect)))  # 2=QtCore.Qt.Checked, 0=QtCore.Qt.Unchecked
         else:
             item.setSelected(doSelect)
 


### PR DESCRIPTION
Some Qt versions (PySide6) do not recognize the int/bool type in checkstate

This patch now makes use of the QtCore.Qt.CheckState type for direct comparison