### PR TITLE
Mwe of a toml config defining a custom group

### DIFF
--- a/src/pymodaq_gui/examples/custom_group_toml.py
+++ b/src/pymodaq_gui/examples/custom_group_toml.py
@@ -1,0 +1,89 @@
+from pathlib import Path
+import datetime
+
+import toml
+
+from pymodaq_utils import config as config_mod
+from pymodaq_gui.utils.widgets.tree_toml import TreeFromToml
+from pymodaq_gui.parameter.pymodaq_ptypes import registerParameterType, GroupParameter
+
+config_path = Path('./custom_toml_group.toml')
+
+
+class CustomConfig(config_mod.BaseConfig):
+    """Main class to deal with configuration values for this plugin"""
+    config_template_path = config_path
+    config_name = f"custom_settings"
+
+
+child_template = [
+    {'title': 'Do it?:', 'name': 'do_it', 'type': 'bool', 'value': True},
+    {'title': 'Choose:', 'name': 'choice', 'type': 'list', 'value': 'ok',
+     'limits': ['ok', 'nonok']},
+]
+
+
+class ScalableCustomGroup(GroupParameter):
+    """
+        |
+
+        ================ =============
+        **Attributes**    **Type**
+        *opts*            dictionnary
+        ================ =============
+
+        See Also
+        --------
+        hardware.DAQ_Move_Stage_type
+    """
+
+    def __init__(self, **opts):
+        opts['type'] = 'mycustomgroupparameter'
+        opts['addText'] = "Add"
+        opts['addList'] = [str(ind) for ind in range(10)]
+        super().__init__(**opts)
+
+    def addNew(self, typ):
+        """
+            Add a child.
+
+            =============== ===========
+            **Parameters**   **Type**
+            *typ*            string
+            =============== ===========
+        """
+        name_prefix = 'template'
+
+        child_indexes = [int(par.name()[len(name_prefix) + 1:]) for par in self.children()[1:]]
+
+        if child_indexes == []:
+            newindex = 0
+        else:
+            newindex = max(child_indexes) + 1
+
+        children = []
+        for ind_child in range(int(typ)):
+            newindex += ind_child
+            children.append({'title': 'Template {:02.0f}'.format(newindex),
+                             'name': f'{name_prefix}{newindex:02.0f}',
+                             'type': 'group',
+                             'removable': True, 'children': child_template})
+
+        self.addChildren(children)
+
+
+registerParameterType('mycustomgroupparameter', ScalableCustomGroup, override=True)
+
+
+if __name__ == '__main__':
+    from pymodaq_gui.utils.utils import mkQApp
+
+    app = mkQApp('Dashboard')
+
+    config = CustomConfig()
+
+    tree_toml = TreeFromToml(config)
+    tree_toml.show_dialog()
+
+    app.exec()
+

--- a/src/pymodaq_gui/examples/custom_toml_group.toml
+++ b/src/pymodaq_gui/examples/custom_toml_group.toml
@@ -1,0 +1,9 @@
+title = 'this is the configuration file of the plugin XXX'
+
+[astandardgroup]
+afloat = 12.3
+aint = 8
+
+[acustomgroup]
+group_type = 'mycustomgroupparameter'
+

--- a/src/pymodaq_gui/utils/widgets/tree_toml.py
+++ b/src/pymodaq_gui/utils/widgets/tree_toml.py
@@ -82,8 +82,9 @@ class TreeFromToml(QObject):
         params = []
         for key in config:
             if isinstance(config[key], dict):
+                ptype = config[key].get('group_type', 'group')
                 params.append({'title': f'{key.capitalize() if capitalize else key}:',
-                               'name': key, 'type': 'group',
+                               'name': key, 'type': ptype,
                                'children': cls.dict_to_param(config[key], capitalize=capitalize),
                                'expanded': 'user' in key.lower() or 'general' in key.lower()})
             else:

--- a/tests/data/custom_toml_group.toml
+++ b/tests/data/custom_toml_group.toml
@@ -1,0 +1,9 @@
+title = 'this is the configuration file of the plugin XXX'
+
+[astandardgroup]
+afloat = 12.3
+aint = 8
+
+[acustomgroup]
+group_type = 'mycustomgroupparameter'
+

--- a/tests/utils/config_test.py
+++ b/tests/utils/config_test.py
@@ -9,6 +9,7 @@ from pyqtgraph.parametertree import Parameter
 from pymodaq_gui.config import ConfigSaverLoader, get_set_roi_path
 
 
+
 class CustomConfig(config_mod.BaseConfig):
     """Main class to deal with configuration values for this plugin"""
     config_template_path = None
@@ -57,4 +58,3 @@ class TestConfigSaverLoader:
         saver_loader.load_config(settings)
 
         assert settings['aparent', 'anotherparam', 'max'] == value_before
-


### PR DESCRIPTION
solving https://github.com/PyMoDAQ/PyMoDAQ/issues/473

In order to use more the plugin config file, it would be nice if a toml entry could be linked to a custom ParameterItem in the ParameterTree in the GUI. For instance a "group" (assigned to a ParameterGroup in the GUI) could be transformed into a scalable group, that would allow to add quickly some configurations. For instance, a keithley instruments can have dozens of channels. Adding some in the configuration file using a scalable group would be nice

The solution introduced by this PR is to add a parameter_type entry in the toml. The toml to Parameter parser would then try to load the corresponding Parameter or the default if no parameter_type is set!

a mwe is written in examples