### PR TITLE
fixed get_entrypoint import

### DIFF
--- a/src/pymodaq_gui/h5modules/utils.py
+++ b/src/pymodaq_gui/h5modules/utils.py
@@ -9,7 +9,7 @@ from collections import OrderedDict
 from typing import List, Dict
 from pathlib import Path
 from importlib import import_module
-from ..daq_utils import get_entrypoints
+from pymodaq_utils.utils import get_entrypoints
 
 # 3rd party imports
 import numpy as np


### PR DESCRIPTION
While writing the doc, i see this import with the wrong path, i figured it's from pymodaq_utils.utils.

Side note : function pymodaq_gui.h5modules.utils.get_h5_attributes is also defined in pymodaq_data.