### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,7 +81,7 @@ jobs:
           pytest -vv --cov=pymodaq_gui -n 1
           mv .coverage coverage/coverage_${{ matrix.os }}_${{ matrix.python-version }}_${{ matrix.qt-backend }}
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4.6.0
+        uses: actions/upload-artifact@v4.6.1
         with:
           name: coverage-${{ matrix.os }}-${{ matrix.python-version }}_${{ matrix.qt-backend }}
           path: coverage/coverage_${{ matrix.os }}_${{ matrix.python-version }}_${{ matrix.qt-backend }}
@@ -113,7 +113,7 @@ jobs:
 
       - name: Upload badge artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4.6.0
+        uses: actions/upload-artifact@v4.6.1
         with:
           name:  tests_${{runner.os}}_${{matrix.python-version}}_${{matrix.qt-backend}}
           path: '${{ steps.extract_branch.outputs.branch }}/tests_${{runner.os}}_${{matrix.python-version}}_${{matrix.qt-backend}}.svg'
@@ -132,7 +132,7 @@ jobs:
           ref: badges
      
       - name: Download badges
-        uses: actions/download-artifact@v4.1.8
+        uses: actions/download-artifact@v4.1.9
 
       - name: Reorganize badges
         run: |
@@ -165,7 +165,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Download all coverage artifacts
-        uses: actions/download-artifact@v4.1.8
+        uses: actions/download-artifact@v4.1.9
         with:
           path: ./coverage-reports
 
@@ -186,7 +186,7 @@ jobs:
           coverage xml -i
 
       - name: Upload combined coverage report to Codecov
-        uses: codecov/codecov-action@v5.3.1
+        uses: codecov/codecov-action@v5.4.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v5.4.0](https://github.com/codecov/codecov-action/releases/tag/v5.4.0)** on 2025-02-26T23:41:16Z
* **[actions/download-artifact](https://github.com/actions/download-artifact)** published a new release **[v4.1.9](https://github.com/actions/download-artifact/releases/tag/v4.1.9)** on 2025-02-25T21:26:04Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.6.1](https://github.com/actions/upload-artifact/releases/tag/v4.6.1)** on 2025-02-21T19:00:26Z
