### PR TITLE
bugfix/using_class_attributes_instead_of_instances_attributes (Pyside6 compatibility)

### DIFF
--- a/src/pymodaq_gui/h5modules/browsing.py
+++ b/src/pymodaq_gui/h5modules/browsing.py
@@ -362,11 +362,14 @@ class H5Browser(QObject, ActionManager):
     def show_about(self):
         splash_path = os.path.join(os.path.split(os.path.split(__file__)[0])[0], 'splash.png')
         splash = QtGui.QPixmap(splash_path)
-        self.splash_sc = QtWidgets.QSplashScreen(splash, QtCore.Qt.WindowStaysOnTopHint)
+        self.splash_sc = QtWidgets.QSplashScreen(splash, QtCore.Qt.WindoWindowStaysOnTopHint)
         self.splash_sc.setVisible(True)
-        self.splash_sc.showMessage(f"PyMoDAQ version {utils.get_version()}\n"
-                                   f"Modular Acquisition with Python\nWritten by Sébastien Weber",
-                                   QtCore.Qt.AlignRight, QtCore.Qt.white)
+        self.splash_sc.showMessage(
+            f"PyMoDAQ version {utils.get_version()}\n"
+            f"Modular Acquisition with Python\nWritten by Sébastien Weber",
+            QtCore.Qt.AlignmentFlag.AlignRight,
+            QtCore.Qt.GlobalColor.white,
+        )
 
     @staticmethod
     def show_log():
@@ -520,9 +523,9 @@ def browse_data(fname=None, ret_all=False, message=None) -> Tuple[data_saving.Da
         dialog.setLayout(vlayout)
         buttonBox = QtWidgets.QDialogButtonBox(parent=dialog)
 
-        buttonBox.addButton('OK', buttonBox.AcceptRole)
+        buttonBox.addButton("OK", QtWidgets.QDialogButtonBox.ButtonRole.AcceptRole)
         buttonBox.accepted.connect(dialog.accept)
-        buttonBox.addButton('Cancel', buttonBox.RejectRole)
+        buttonBox.addButton("Cancel", QtWidgets.QDialogButtonBox.ButtonRole.RejectRole)
         buttonBox.rejected.connect(dialog.reject)
         vlayout.addWidget(buttonBox)
 
@@ -533,7 +536,7 @@ def browse_data(fname=None, ret_all=False, message=None) -> Tuple[data_saving.Da
             dialog.setWindowTitle(message)
         res = dialog.exec()
 
-        if res == dialog.Accepted:
+        if res == QtWidgets.QDialog.DialogCode.Accepted:
             node_path = browser.current_node_path
             data = dataloader.load_data(node_path, with_bkg=True)
         else:

--- a/src/pymodaq_gui/managers/roi_manager.py
+++ b/src/pymodaq_gui/managers/roi_manager.py
@@ -67,16 +67,16 @@ class ROIPositionMapper(QtWidgets.QWidget):
         dialog.setLayout(vlayout)
 
         buttonBox = QtWidgets.QDialogButtonBox(parent=self)
-        buttonBox.addButton('Apply', buttonBox.AcceptRole)
+        buttonBox.addButton("Apply", QtWidgets.QDialogButtonBox.ButtonRole.AcceptRole)
         buttonBox.accepted.connect(dialog.accept)
-        buttonBox.addButton('Cancel', buttonBox.RejectRole)
+        buttonBox.addButton("Cancel", QtWidgets.QDialogButtonBox.ButtonRole.RejectRole)
         buttonBox.rejected.connect(dialog.reject)
 
         vlayout.addWidget(buttonBox)
         self.setWindowTitle('Set Precise positions for the ROI')
         res = dialog.exec()
 
-        if res == dialog.Accepted:
+        if res == QtWidgets.QDialog.DialogCode.Accepted:
 
             return self.settings
         else:
@@ -642,9 +642,9 @@ class ROISaver:
             msgBox = QtWidgets.QMessageBox()
             msgBox.setText("ROI Manager?")
             msgBox.setInformativeText("What do you want to do?")
-            cancel_button = msgBox.addButton(QtWidgets.QMessageBox.Cancel)
-            modify_button = msgBox.addButton('Modify', QtWidgets.QMessageBox.AcceptRole)
-            msgBox.setDefaultButton(QtWidgets.QMessageBox.Cancel)
+            cancel_button = msgBox.addButton(QtWidgets.QMessageBox.StandardButton.Cancel)
+            modify_button = msgBox.addButton('Modify', QtWidgets.QMessageBox.ButtonRole.AcceptRole)
+            msgBox.setDefaultButton(QtWidgets.QMessageBox.StandardButton.Cancel)
             ret = msgBox.exec()
 
             if msgBox.clickedButton() == modify_button:
@@ -734,7 +734,7 @@ class ROISaver:
         dialog.setWindowTitle('Fill in information about this manager')
         res = dialog.exec()
 
-        if res == dialog.Accepted:
+        if res == QtWidgets.QDialog.DialogCode.Accepted:
             # save managers parameters in a xml file
             # start = os.path.split(os.path.split(os.path.realpath(__file__))[0])[0]
             # start = os.path.join("..",'daq_scan')

--- a/src/pymodaq_gui/messenger.py
+++ b/src/pymodaq_gui/messenger.py
@@ -21,7 +21,7 @@ def messagebox(severity='warning', title='this is a title', text='blabla'):
     assert severity in MESSAGE_SEVERITIES
     messbox = getattr(QtWidgets.QMessageBox, severity)
     ret = messbox(None, title, text)
-    return ret == QtWidgets.QMessageBox.Ok
+    return ret == QtWidgets.QMessageBox.StandardButton.Ok
 
 
 def dialog(title='', message='', widget=None):
@@ -29,10 +29,10 @@ def dialog(title='', message='', widget=None):
     dlg.setWindowTitle(title)
     dlg.setLayout(QtWidgets.QVBoxLayout())
     label = QtWidgets.QLabel(message)
-    label.setAlignment(QtCore.Qt.AlignCenter)
+    label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
     dlg.layout().addWidget(label)
     dlg.layout().addWidget(widget)
-    button_box = QtWidgets.QDialogButtonBox(QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel)
+    button_box = QtWidgets.QDialogButtonBox(QtWidgets.QDialogButtonBox.StandardButton.Ok | QtWidgets.QDialogButtonBox.StandardButton.Cancel)
     dlg.layout().addWidget(button_box)
     button_box.accepted.connect(dlg.accept)
     button_box.rejected.connect(dlg.reject)

--- a/src/pymodaq_gui/utils/list_picker.py
+++ b/src/pymodaq_gui/utils/list_picker.py
@@ -20,9 +20,9 @@ class ListPicker(QObject):
         self.dialog.setLayout(vlayout)
 
         buttonBox = QtWidgets.QDialogButtonBox()
-        buttonBox.addButton('Apply', buttonBox.AcceptRole)
+        buttonBox.addButton("Apply", QtWidgets.QDialogButtonBox.ButtonRole.AcceptRole)
         buttonBox.accepted.connect(self.dialog.accept)
-        buttonBox.addButton('Cancel', buttonBox.RejectRole)
+        buttonBox.addButton('Cancel', QtWidgets.QDialogButtonBox.ButtonRole.RejectRole)
         buttonBox.rejected.connect(self.dialog.reject)
 
         vlayout.addWidget(buttonBox)
@@ -31,7 +31,7 @@ class ListPicker(QObject):
         res = self.dialog.show()
 
         pass
-        if res == self.dialog.Accepted:
+        if res == QtWidgets.QDialog.DialogCode.Accepted:
             # save managers parameters in a xml file
             return [self.list_widget.currentIndex(), self.list_widget.currentItem().text()]
         else:

--- a/src/pymodaq_gui/utils/splash.py
+++ b/src/pymodaq_gui/utils/splash.py
@@ -10,14 +10,13 @@ class MySplash(QtWidgets.QSplashScreen):
         here = Path(__file__)
         pixmap = QtGui.QPixmap(str(here.parent.parent.joinpath('splash.png')))
         super().__init__(pixmap, Qt.WindowStaysOnTopHint, *args, **kwargs)
-
         font = self.font()
         font.setPixelSize(18)
         self.setFont(font)
 
     def showMessage(self, message, *args, **kwargs):
         """ force any message to be printed in white in the right/top corner """
-        super().showMessage(message, QtCore.Qt.AlignRight, QtCore.Qt.white,
+        super().showMessage(message, QtCore.Qt.AlignmentFlag.AlignRight, QtCore.Qt.GlobalColor.white,
                             )
 
 def get_splash_sc() -> MySplash:

--- a/src/pymodaq_gui/utils/widgets/tree_toml.py
+++ b/src/pymodaq_gui/utils/widgets/tree_toml.py
@@ -39,9 +39,9 @@ class TreeFromToml(QObject):
         self.dialog.setLayout(QtWidgets.QVBoxLayout())
         buttonBox = QtWidgets.QDialogButtonBox(parent=self.dialog)
 
-        buttonBox.addButton('Save', buttonBox.AcceptRole)
+        buttonBox.addButton('Save', buttonBox.ButtonRole.AcceptRole)
         buttonBox.accepted.connect(self.dialog.accept)
-        buttonBox.addButton('Cancel', buttonBox.RejectRole)
+        buttonBox.addButton('Cancel', buttonBox.ButtonRole.RejectRole)
         buttonBox.rejected.connect(self.dialog.reject)
 
         self.dialog.layout().addWidget(self.settings_tree)
@@ -49,7 +49,7 @@ class TreeFromToml(QObject):
         self.dialog.setWindowTitle('Configuration entries')
         res = self.dialog.exec()
 
-        if res == self.dialog.Accepted:
+        if res == self.dialog.DialogCode.Accepted:
             with open(self._config.config_path, 'w') as f:
                 config_dict = self.param_to_dict(self.settings)
                 config_dict.pop('config_path')

--- a/src/pymodaq_gui/utils/widgets/tree_toml.py
+++ b/src/pymodaq_gui/utils/widgets/tree_toml.py
@@ -49,7 +49,7 @@ class TreeFromToml(QObject):
         self.dialog.setWindowTitle('Configuration entries')
         res = self.dialog.exec()
 
-        if res == self.dialog.DialogCode.Accepted:
+        if res == QtWidgets.QDialog.DialogCode.Accepted:
             with open(self._config.config_path, 'w') as f:
                 config_dict = self.param_to_dict(self.settings)
                 config_dict.pop('config_path')

--- a/src/pymodaq_gui/utils/widgets/tree_toml.py
+++ b/src/pymodaq_gui/utils/widgets/tree_toml.py
@@ -39,9 +39,9 @@ class TreeFromToml(QObject):
         self.dialog.setLayout(QtWidgets.QVBoxLayout())
         buttonBox = QtWidgets.QDialogButtonBox(parent=self.dialog)
 
-        buttonBox.addButton('Save', buttonBox.ButtonRole.AcceptRole)
+        buttonBox.addButton('Save', QtWidgets.QDialogButtonBox.ButtonRole.AcceptRole)
         buttonBox.accepted.connect(self.dialog.accept)
-        buttonBox.addButton('Cancel', buttonBox.ButtonRole.RejectRole)
+        buttonBox.addButton("Cancel", QtWidgets.QDialogButtonBox.ButtonRole.RejectRole)
         buttonBox.rejected.connect(self.dialog.reject)
 
         self.dialog.layout().addWidget(self.settings_tree)


### PR DESCRIPTION
With PySide6 after starting the dashboard:
when one wants to access a tree_toml (pressing Utils Config or Controls/Extension Config) would trigger this error.

```
Traceback (most recent call last):
  File "C:\Users\constant.schouder\Documents\PyMoDAQ\PyMoDAQ\src\pymodaq\dashboard.py", line 774, in <lambda>
    self.connect_action("config_utils", lambda: self.show_config(config_utils))
  File "C:\Users\constant.schouder\Documents\PyMoDAQ\PyMoDAQ\src\pymodaq\dashboard.py", line 2089, in show_config
    config_tree.show_dialog()
  File "C:\Users\constant.schouder\Documents\PyMoDAQ\pymodaq_gui\src\pymodaq_gui\utils\widgets\tree_toml.py", line 42, in show_dialog
    buttonBox.addButton('Save', buttonBox.AcceptRole)
AttributeError: 'PySide6.QtWidgets.QDialogButtonBox' object has no attribute 'AcceptRole'. Did you mean: 'acceptDrops'?

```

The reason is the lazy use of `buttonBox.AcceptRole`. This is now replaced with the explicit syntax `buttonBox.ButtonRole.AcceptRole`