### PR TITLE
Feature/update list order when saving

### DIFF
--- a/src/pymodaq_gui/__init__.py
+++ b/src/pymodaq_gui/__init__.py
@@ -4,7 +4,7 @@ import sys
 import pkgutil
 
 def set_and_check_qt_backend_or_die(config):
-    wanted_backend = config('qtbackend', 'backend')
+    wanted_backend = config('qtbackend', 'backends')[0]
     backend = wanted_backend
     #filter to get only qt backend modules
     available_backends = [mod.name.lower() for mod in pkgutil.iter_modules() \
@@ -54,7 +54,7 @@ from pymodaq_utils.logger import set_logger
 logger = set_logger('pymodaq_gui', base_logger=False)
 
 logger.info('Starting PyMoDAQ GUI modules')
-logger.info(f"Trying to set Qt backend to: {config['qtbackend']['backend']}")
+logger.info(f"Trying to set Qt backend to: {config['qtbackend']['backends'][0]}")
 set_and_check_qt_backend_or_die(config)
 
 

--- a/src/pymodaq_gui/utils/widgets/tree_toml.py
+++ b/src/pymodaq_gui/utils/widgets/tree_toml.py
@@ -72,7 +72,10 @@ class TreeFromToml(QObject):
                     pdt = datetime.fromtimestamp(qdt.toSecsSinceEpoch())
                     config[child.name()] = pdt.date()
                 elif child.opts['type'] == 'list':
-                    config[child.name()] = child.opts['limits']
+                    if child.opts['value'] in child.opts['limits']:
+                        child.opts["limits"].remove(child.opts['value'])
+                        child.opts["limits"].insert(0,child.opts["value"])
+                    config[child.name()] = child.opts["limits"]
                 else:
                     config[child.name()] = child.value()
         return config

--- a/src/pymodaq_gui/utils/widgets/tree_toml.py
+++ b/src/pymodaq_gui/utils/widgets/tree_toml.py
@@ -39,9 +39,9 @@ class TreeFromToml(QObject):
         self.dialog.setLayout(QtWidgets.QVBoxLayout())
         buttonBox = QtWidgets.QDialogButtonBox(parent=self.dialog)
 
-        buttonBox.addButton('Save', buttonBox.AcceptRole)
+        buttonBox.addButton('Save', buttonBox.ButtonRole.AcceptRole)
         buttonBox.accepted.connect(self.dialog.accept)
-        buttonBox.addButton('Cancel', buttonBox.RejectRole)
+        buttonBox.addButton('Cancel', buttonBox.ButtonRole.RejectRole)
         buttonBox.rejected.connect(self.dialog.reject)
 
         self.dialog.layout().addWidget(self.settings_tree)
@@ -49,7 +49,7 @@ class TreeFromToml(QObject):
         self.dialog.setWindowTitle('Configuration entries')
         res = self.dialog.exec()
 
-        if res == self.dialog.Accepted:
+        if res == self.dialog.DialogCode.Accepted:
             with open(self._config.config_path, 'w') as f:
                 config_dict = self.param_to_dict(self.settings)
                 config_dict.pop('config_path')

--- a/src/pymodaq_gui/utils/widgets/tree_toml.py
+++ b/src/pymodaq_gui/utils/widgets/tree_toml.py
@@ -64,12 +64,12 @@ class TreeFromToml(QObject):
                 config[child.name()] = cls.param_to_dict(child)
             else:
                 if child.opts['type'] == 'datetime':
-                    config[child.name()] = datetime.fromtimestamp(
+                    config[child.name()] = datetime.datetime.fromtimestamp(
                         child.value().toSecsSinceEpoch())  # convert QDateTime to python datetime
                 elif child.opts['type'] == 'date':
                     qdt = QtCore.QDateTime()
                     qdt.setDate(child.value())
-                    pdt = datetime.fromtimestamp(qdt.toSecsSinceEpoch())
+                    pdt = datetime.datetime.fromtimestamp(qdt.toSecsSinceEpoch())
                     config[child.name()] = pdt.date()
                 elif child.opts['type'] == 'list':
                     if child.opts['value'] in child.opts['limits']:

--- a/src/pymodaq_gui/utils/widgets/tree_toml.py
+++ b/src/pymodaq_gui/utils/widgets/tree_toml.py
@@ -108,6 +108,6 @@ class TreeFromToml(QObject):
                     param['type'] = 'list'
                     param['limits'] = config[key]
                     param['value'] = config[key][0]
-                    param['show_pb'] = True
+                    # param['show_pb'] = True # If True, this allows the user to change the limits in the list from the GUI. No need for now.
                 params.append(param)
         return params


### PR DESCRIPTION
This PR is related to the behavior or tree_toml which can be unintuitive.

Currently, in the toml tree we are using lists in the following manner.
There is one entry that is associated to the list and one entry that is associated to the desired value.
![toml_tree](https://github.com/user-attachments/assets/c64a2189-b8ca-4a60-bb5a-d32cbd91b2f4)

If one wants to use a particular value, he has to type a value that can be found in the list. In that case, the list only serves as an indication of the "allowed" values.
It would be much more intuitive, if the user would select the desired item in the list as this would be bullet proof against wrong values.

Since pymodaq and pymodaq_gui are now separated, it is difficult to progress on both parts. In this PR, we specifically change the ordering of the parameter list when the toml is being saved.
In practice, when one save the settings, the selected item will be moved to the first position. The key idea is that once we read the Config, we only read the first entry to get the desired value.

Overall, this avoids useless repetitions in the settings. In addition, it prepares the path to fully make use of list in the toml tree for all the "accessible" settings without having to type them manually.
