### PR TITLE
Bugfix/Resize_to_content is standard behavior for ParameterTree

### DIFF
--- a/src/pymodaq_gui/parameter/__init__.py
+++ b/src/pymodaq_gui/parameter/__init__.py
@@ -9,5 +9,5 @@ class ParameterTree(ParameterTree):
         super().__init__(*args, **kwargs)
 
         self.header().setVisible(True)
-        self.header().setSectionResizeMode(QtWidgets.QHeaderView.Interactive)
+        self.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
         #self.header().setMinimumSectionSize(150)

--- a/src/pymodaq_gui/utils/widgets/tree_toml.py
+++ b/src/pymodaq_gui/utils/widgets/tree_toml.py
@@ -31,9 +31,6 @@ class TreeFromToml(QObject):
                                          children=params)
         self.settings_tree = ParameterTree()
         self.settings_tree.setParameters(self.settings, showTop=False)
-        self.settings_tree.header().setSectionResizeMode(
-            QtWidgets.QHeaderView.ResizeMode.ResizeToContents
-        )
 
     def show_dialog(self) -> bool:
 

--- a/src/pymodaq_gui/utils/widgets/tree_toml.py
+++ b/src/pymodaq_gui/utils/widgets/tree_toml.py
@@ -31,6 +31,9 @@ class TreeFromToml(QObject):
                                          children=params)
         self.settings_tree = ParameterTree()
         self.settings_tree.setParameters(self.settings, showTop=False)
+        self.settings_tree.header().setSectionResizeMode(
+            QtWidgets.QHeaderView.ResizeMode.ResizeToContents
+        )
 
     def show_dialog(self) -> bool:
 


### PR DESCRIPTION
The ParameterTree settings generated from the config file (using tree_toml.py) do not resize correctly.

This is related to #65 which implemented it in the context of the preset.

This PR makes the standard behavior of the tree to be in ResizeToContents mode.

This problem was already pointed a few times and I wonder if this should be the default behavior of any ParameterTree. In that case, we should just change it in the `__init__` directly (`\src\pymodaq_gui\parameter\__init__.py`) which explicitely call the         
````
self.header().setSectionResizeMode(QtWidgets.QHeaderView.Interactive)
````
and replace it by 
```
self.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
```