### PR TITLE
Display the title on the viewer windows

### DIFF
--- a/src/pymodaq_gui/plotting/data_viewers/base.py
+++ b/src/pymodaq_gui/plotting/data_viewers/base.py
@@ -175,6 +175,8 @@ class ViewerBase(QObject):
             parent.show()
         self.parent = parent
 
+        self.parent.setWindowTitle(self.title)
+
         self._display_temporary = False
 
     @property

--- a/src/pymodaq_gui/plotting/data_viewers/viewer.py
+++ b/src/pymodaq_gui/plotting/data_viewers/viewer.py
@@ -88,7 +88,7 @@ class ViewerDispatcher:
     def __init__(self, dockarea: DockArea = None, title: str = '', next_to_dock: Dock = None,
                  direction='right'):
         super().__init__()
-        self._title = title
+        self._title = title if title != '' else self.__class__.__name__
 
         self._next_to_dock = next_to_dock
 

--- a/src/pymodaq_gui/plotting/data_viewers/viewer.py
+++ b/src/pymodaq_gui/plotting/data_viewers/viewer.py
@@ -96,6 +96,7 @@ class ViewerDispatcher:
             dockarea = DockArea()
             dockarea.show()
         self.dockarea = dockarea
+        self.dockarea.setWindowTitle(title)
 
         self._direction = direction
 


### PR DESCRIPTION
Hi!
I noticed while playing around analyzing some data that the windows of the data viewers had no title, even when I gave one during the init. This was not very convenient as I often have several windows with viewers opened. 

I added a line in the ViewerBase and in the ViewerDispatcher definition to display the title. Now it looks like this:

![screenshot_gui](https://github.com/user-attachments/assets/80dc074c-ac57-482f-9bc5-23c90817cd03)

Tested with PyQt6 on Linux, and I also checked that it does not mess up the dashboard in PyMoDAQ.

Cheers,
Aurore