### PR TITLE
Changes to allow optional ROI data processing

### DIFF
--- a/src/pymodaq_gui/managers/roi_manager.py
+++ b/src/pymodaq_gui/managers/roi_manager.py
@@ -95,6 +95,8 @@ class ROIScalableGroup(GroupParameter):
     def make_ROIParam2D(roi_type, index):
             children = []    
             children.extend([{'title': 'Type', 'name': 'roi_type', 'type': 'list', 'value': roi_type, 'limits':['RectROI','EllipseROI','CircularROI'], 'readonly': False,}])
+            children.append({'title': 'Process data', 'name': 'process_data', 'type': 'led_push', 
+                             'value': False, 'default': False})
             children.extend(ROIScalableGroup.makeChannelsParam('2D'))
             children.extend(ROIScalableGroup.makeMathParam('2D'))
             children.extend(ROIScalableGroup.makeDisplayParam(index))
@@ -116,7 +118,9 @@ class ROIScalableGroup(GroupParameter):
 
     @staticmethod    
     def make_ROIParam1D(roi_type, index):
-            children = []    
+            children = []
+            children.append({'title': 'Process data', 'name': 'process_data', 'type': 'led_push', 
+                             'value': False, 'default': False})            
             children.extend(ROIScalableGroup.makeChannelsParam('1D'))
             children.extend(ROIScalableGroup.makeMathParam('1D'))
             children.extend(ROIScalableGroup.makeDisplayParam(index))
@@ -134,6 +138,7 @@ class ROIManager(QObject):
     new_ROI_signal = Signal(str)
     remove_ROI_signal = Signal(str)
     roi_value_changed = Signal(str, tuple)
+    roi_process_data_changed = Signal(bool, str)
     color_signal = Signal(list)
     roi_update_children = Signal(list)
     roi_changed = Signal()
@@ -433,6 +438,8 @@ class ROIManager(QObject):
         elif param.name() == 'height':
             size = roi.size()
             roi.setSize((size[0], param.value()))
+        elif param.name() == 'process_data':
+            self.roi_process_data_changed.emit(param.value(), roi_key)            
 
         self.update_roi_tree(roi)
         roi.signalBlocker.unblock()
@@ -454,7 +461,6 @@ class ROIManager(QObject):
     @Slot(type(ROI))
     def update_roi_tree(self, roi):
         par = self.get_parameter(roi)        
-
         if isinstance(roi, LinearROI):
             pos = roi.getRegion()
         else:

--- a/src/pymodaq_gui/managers/roi_manager.py
+++ b/src/pymodaq_gui/managers/roi_manager.py
@@ -18,6 +18,7 @@ from pymodaq_gui.managers.action_manager import QAction
 
 from pymodaq_utils.utils import plot_colors
 from pymodaq_utils.logger import get_module_name, set_logger
+from pymodaq_utils.config import Config
 from pymodaq_gui.config_saver_loader import get_set_roi_path
 from pymodaq_gui.utils import select_file
 from pymodaq_gui.plotting.items.roi import RectROI,LinearROI,EllipseROI,CircularROI,ROI
@@ -32,15 +33,15 @@ data_processors = DataProcessorFactory()
 
 roi_path = get_set_roi_path()
 logger = set_logger(get_module_name(__file__))
-translate = QtCore.QCoreApplication.translate
-
+config = Config()
 
 ROI_NAME_PREFIX = 'ROI_'
 ROI2D_TYPES = ['RectROI', 'EllipseROI', 'CircularROI']
 
-ROI_NAME_PREFIX = 'ROI_'
+
 def roi_format(index):
     return f'{ROI_NAME_PREFIX}{index:02d}'
+
 
 class ROIScalableGroup(GroupParameter):
     def __init__(self, roi_type='1D', **opts):
@@ -96,7 +97,7 @@ class ROIScalableGroup(GroupParameter):
             children = []    
             children.extend([{'title': 'Type', 'name': 'roi_type', 'type': 'list', 'value': roi_type, 'limits':['RectROI','EllipseROI','CircularROI'], 'readonly': False,}])
             children.append({'title': 'Process data', 'name': 'process_data', 'type': 'led_push', 
-                             'value': False, 'default': False})
+                             'value': config.get(('plotting', 'process_roi'), True),})
             children.extend(ROIScalableGroup.makeChannelsParam('2D'))
             children.extend(ROIScalableGroup.makeMathParam('2D'))
             children.extend(ROIScalableGroup.makeDisplayParam(index))
@@ -119,8 +120,8 @@ class ROIScalableGroup(GroupParameter):
     @staticmethod    
     def make_ROIParam1D(roi_type, index):
             children = []
-            children.append({'title': 'Process data', 'name': 'process_data', 'type': 'led_push', 
-                             'value': False, 'default': False})            
+            children.append({'title': 'Process data', 'name': 'process_data', 'type': 'led_push',
+                             'value': config.get(('plotting', 'process_roi'), True),})
             children.extend(ROIScalableGroup.makeChannelsParam('1D'))
             children.extend(ROIScalableGroup.makeMathParam('1D'))
             children.extend(ROIScalableGroup.makeDisplayParam(index))
@@ -130,7 +131,6 @@ class ROIScalableGroup(GroupParameter):
                     ]}, ])
             
             return children
-
 
 
 class ROIManager(QObject):
@@ -235,6 +235,7 @@ class ROIManager(QObject):
                 self.add_ROI(roi)
                 self.emit_colors()
                 self.roi_changed.emit()
+                self.roi_process_data_changed.emit(par['process_data'], roi.key())
 
             elif change == 'value':
                 if param.name() in putils.iter_children(self.settings.child('ROIs'), []):
@@ -439,7 +440,7 @@ class ROIManager(QObject):
             size = roi.size()
             roi.setSize((size[0], param.value()))
         elif param.name() == 'process_data':
-            self.roi_process_data_changed.emit(param.value(), roi_key)            
+            self.roi_process_data_changed.emit(param.value(), roi.key())
 
         self.update_roi_tree(roi)
         roi.signalBlocker.unblock()

--- a/src/pymodaq_gui/plotting/data_viewers/viewer1D.py
+++ b/src/pymodaq_gui/plotting/data_viewers/viewer1D.py
@@ -595,6 +595,7 @@ class Viewer1D(ViewerBase):
 
     def prepare_connect_ui(self):
         self.view.ROIselect.sigRegionChangeFinished.connect(self.selected_region_changed)
+        self.roi_manager.roi_process_data_changed.connect(self.roi_process_data_changed)
         self._data_to_show_signal.connect(self.view.display_data)
         self.roi_manager.roi_changed.connect(self.roi_changed)
         self.roi_manager.roi_value_changed.connect(self.roi_changed)
@@ -614,6 +615,26 @@ class Viewer1D(ViewerBase):
 
     def roi_changed(self):
         self.filter_from_rois.filter_data(self._raw_data)
+
+    def roi_process_data_changed(self, process_data: bool, roi_key: str):
+        roi = self.roi_manager._ROIs[roi_key]
+        self.filter_from_rois.set_roi_active(roi_key, process_data)
+        if process_data:
+            if self.filter_from_rois._slot_to_send_data is None:
+                self.filter_from_rois.register_target_slot(self.process_roi_lineouts)
+            self.view.add_roi_displayer(roi_key)
+        else:
+            self.view.remove_roi_displayer(roi.name)
+            self.data_to_export = DataToExport([
+                dwa for dwa in self.data_to_export.data
+                if getattr(dwa, "origin", None) != roi.name
+            ])
+        if hasattr(self, 'measure_data_dict'):
+            keys_to_remove = [k for k in self.measure_data_dict if k.startswith(f"{roi.name}/")
+                              or k.endswith(f":")]
+            for k in keys_to_remove:
+                self.measure_data_dict.pop(k, None)
+            self.view.roi_manager.settings.child('measurements').setValue(self.measure_data_dict)
 
     def crosshair_changed(self):
         self.filter_from_crosshair.filter_data(self._raw_data)

--- a/src/pymodaq_gui/plotting/data_viewers/viewer2D.py
+++ b/src/pymodaq_gui/plotting/data_viewers/viewer2D.py
@@ -745,9 +745,9 @@ class Viewer2D(ViewerBase):
 
         self.view = View2D(parent)
         self.filter_from_rois = Filter2DFromRois(self.view.roi_manager, self.view.data_displayer.get_image('red'),
-                                                 IMAGE_TYPES)
+                                        IMAGE_TYPES)
         self.filter_from_rois.register_activation_signal(self.view.get_action('roi').triggered)
-        self.filter_from_rois.register_target_slot(self.process_roi_lineouts)
+        self.filter_from_rois.register_target_slot(self.process_roi_lineouts)        
 
         self.filter_from_crosshair = Filter2DFromCrosshair(self.view.crosshair, self.view.data_displayer.get_images(),
                                                            IMAGE_TYPES)
@@ -935,6 +935,7 @@ class Viewer2D(ViewerBase):
 
     def prepare_connect_ui(self):
         self.view.ROIselect.sigRegionChangeFinished.connect(self.selected_region_changed)
+        self.roi_manager.roi_process_data_changed.connect(self.roi_process_data_changed)
 
         self.roi_manager.roi_changed.connect(self.roi_changed)
         self.roi_manager.roi_value_changed.connect(self.roi_changed)
@@ -969,6 +970,25 @@ class Viewer2D(ViewerBase):
         posx, posy = self.view.scale_axis(posx, posy)
         self.sig_double_clicked.emit(posx, posy)
 
+    def roi_process_data_changed(self, process_data: bool, roi_key: str):
+        roi = self.roi_manager._ROIs[roi_key]
+        self.filter_from_rois.set_roi_active(roi_key, process_data)
+        if process_data:
+            if self.filter_from_rois._slot_to_send_data is None:
+                self.filter_from_rois.register_target_slot(self.process_roi_lineouts)
+            self.view.add_roi_displayer(roi_key, roi_type='', roi_name=roi.name)
+        else:
+            self.view.remove_roi_displayer(roi.name)
+            self.data_to_export = DataToExport([
+                dwa for dwa in self.data_to_export.data
+                if getattr(dwa, "origin", None) != roi.name
+            ])
+        if hasattr(self, 'measure_data_dict'):
+            keys_to_remove = [k for k in self.measure_data_dict if k.startswith(f"{roi.name}/") 
+                            or k.endswith(f":")]
+            for k in keys_to_remove:
+                self.measure_data_dict.pop(k, None)
+            self.view.roi_manager.settings.child('measurements').setValue(self.measure_data_dict)
 
     @property
     def x_axis(self):

--- a/src/pymodaq_gui/plotting/data_viewers/viewer2D.py
+++ b/src/pymodaq_gui/plotting/data_viewers/viewer2D.py
@@ -745,9 +745,9 @@ class Viewer2D(ViewerBase):
 
         self.view = View2D(parent)
         self.filter_from_rois = Filter2DFromRois(self.view.roi_manager, self.view.data_displayer.get_image('red'),
-                                        IMAGE_TYPES)
+                                                 IMAGE_TYPES)
         self.filter_from_rois.register_activation_signal(self.view.get_action('roi').triggered)
-        self.filter_from_rois.register_target_slot(self.process_roi_lineouts)        
+        self.filter_from_rois.register_target_slot(self.process_roi_lineouts)
 
         self.filter_from_crosshair = Filter2DFromCrosshair(self.view.crosshair, self.view.data_displayer.get_images(),
                                                            IMAGE_TYPES)

--- a/src/pymodaq_gui/plotting/data_viewers/viewer2D.py
+++ b/src/pymodaq_gui/plotting/data_viewers/viewer2D.py
@@ -976,7 +976,7 @@ class Viewer2D(ViewerBase):
         if process_data:
             if self.filter_from_rois._slot_to_send_data is None:
                 self.filter_from_rois.register_target_slot(self.process_roi_lineouts)
-            self.view.add_roi_displayer(roi_key, roi_type='', roi_name=roi.name)
+            self.view.add_roi_displayer(roi_key)
         else:
             self.view.remove_roi_displayer(roi.name)
             self.data_to_export = DataToExport([

--- a/src/pymodaq_gui/plotting/utils/filter.py
+++ b/src/pymodaq_gui/plotting/utils/filter.py
@@ -37,6 +37,12 @@ class Filter:
     def register_target_slot(self, slot):
         self._slot_to_send_data = slot
 
+    def unregister_activation_signal(self, activation_signal):
+        activation_signal.disconnect()
+
+    def unregister_target_slot(self):
+        self._slot_to_send_data = None
+
     @Slot(bool)
     def set_active(self, activate=True):
         self._is_active = activate
@@ -232,6 +238,11 @@ class Filter1DFromRois(Filter):
         self._roi_settings = roi_manager.settings
         self._ROIs = roi_manager.ROIs
         self._axis: data_mod.Axis = None
+        self._roi_active = {key: False for key in self._ROIs.keys()}
+
+    def set_roi_active(self, roi_key: str, active: bool):
+        if roi_key in self._ROIs:
+            self._roi_active[roi_key] = active
 
     def update_axis(self, axis: data_mod.Axis):
         self._axis = axis
@@ -244,14 +255,17 @@ class Filter1DFromRois(Filter):
                 self.update_axis(axis)
             if data is not None:                                
                 for roi_key, roi in self._ROIs.items():
-                    sub_data = data.deepcopy()                
-                    labels = self._roi_settings['ROIs', roi_key, 'use_channel']['selected']
-                    if labels:
-                        sub_data.data = [sub_data[sub_data.labels.index(label)] for label in labels]
-                        sub_data.labels = [label for label in labels]                
-                    dte_tmp = self.get_data_from_roi(roi, self._roi_settings.child('ROIs', roi_key),
-                                                                    sub_data)
-                    dte.append(dte_tmp)
+                    if not self._roi_active.get(roi_key, False):
+                        continue 
+                    else:
+                        sub_data = data.deepcopy()                
+                        labels = self._roi_settings['ROIs', roi_key, 'use_channel']['selected']
+                        if labels:
+                            sub_data.data = [sub_data[sub_data.labels.index(label)] for label in labels]
+                            sub_data.labels = [label for label in labels]                
+                        dte_tmp = self.get_data_from_roi(roi, self._roi_settings.child('ROIs', roi_key),
+                                                                        sub_data)
+                        dte.append(dte_tmp)
         except Exception as e:
             logger.warning(f'Issue with the ROI: {str(e)}')
         return dte
@@ -301,6 +315,11 @@ class Filter2DFromRois(Filter):
         self._graph_item = graph_item
         self.axes = (0, 1)
         self._ROIs = roi_manager.ROIs
+        self._roi_active = {key: False for key in self._ROIs.keys()}
+
+    def set_roi_active(self, roi_key: str, active: bool):
+        if roi_key in self._ROIs:
+            self._roi_active[roi_key] = active
 
     def _filter_data(self, dwa: data_mod.DataRaw) -> DataToExport:
         dte = DataToExport('ROI')
@@ -308,11 +327,15 @@ class Filter2DFromRois(Filter):
             try:
                 labels = []
                 for roi_key, roi in self._ROIs.items():
-                    labels = self._roi_settings['ROIs', roi_key, 'use_channel']['selected']
-                    sub_data = dwa.deepcopy()
-                    if labels:
-                        sub_data.data = [dwa[dwa.labels.index(label)] for label in labels]
-                        sub_data.labels = [label for label in labels]
+                    if not self._roi_active.get(roi_key, False):
+                        continue
+                    else:
+                        labels = self._roi_settings['ROIs', roi_key, 'use_channel']['selected']
+                        sub_data = dwa.deepcopy()
+                        if labels:
+                            sub_data.data = [dwa[dwa.labels.index(label)] for label in labels]
+                            sub_data.labels = [label for label in labels]
+
                         dte_temp = self.get_xydata_from_roi(roi, sub_data,
                                                                 self._roi_settings['ROIs',
                                                                 roi_key, 'math_function'])

--- a/src/pymodaq_gui/plotting/utils/filter.py
+++ b/src/pymodaq_gui/plotting/utils/filter.py
@@ -37,12 +37,6 @@ class Filter:
     def register_target_slot(self, slot):
         self._slot_to_send_data = slot
 
-    def unregister_activation_signal(self, activation_signal):
-        activation_signal.disconnect()
-
-    def unregister_target_slot(self):
-        self._slot_to_send_data = None
-
     @Slot(bool)
     def set_active(self, activate=True):
         self._is_active = activate


### PR DESCRIPTION
There are cases where a user would like to have several ROIs in the viewer at once, but does not care about the data in the ROI, or performing any calculations on it. An example would be using a 2D viewer to keep track of a beam and using the ROIs as references. 

When there are multiple ROIs, which are all exporting data and performing calculations, the performance of the application starts to degrade quite a bit, especially for higher frame rate cameras. Therefore, I added some functionality to allow users the option to process data from an ROI. As of now, this disables all filtering, displaying and calculating of the data at once.  