### PR TITLE
Feature/not doing roi calculation

### DIFF
--- a/src/pymodaq_gui/managers/roi_manager.py
+++ b/src/pymodaq_gui/managers/roi_manager.py
@@ -252,21 +252,23 @@ class ROIManager(QObject):
                 if data=='Copy':
                     self.copy_ROI(self.ROIs[param.name()])                    
 
-    def make_ROI(self, par,):
-        newindex = int(par.name()[-2:])
+    def make_ROI(self, param: Parameter):
+        newindex = int(param.name()[-2:])
         pos = self.viewer_widget.plotItem.vb.viewRange()
         if self.ROI_type == '1D':
             roi_type = ''
             pos = pos[0]
             pos = pos[0] + np.diff(pos)*np.array([2,4])/6
-            roi = self.make_ROI1D(newindex,pos,brush=par['Color'])
+            roi = self.make_ROI1D(newindex, pos, brush=param['Color'],
+                                  compute=param['process_data'])
         elif self.ROI_type == '2D':
-            roi_type = par.child('roi_type').value()
+            roi_type = param.child('roi_type').value()
             xrange,yrange=pos                    
             width = np.max(((xrange[1] - xrange[0]) / 10, 2))
             height = np.max(((yrange[1] - yrange[0]) / 10, 2))
             pos = [int(np.mean(xrange) - width / 2), int(np.mean(yrange) - width / 2)]
-            roi = self.make_ROI2D(roi_type,index=newindex, pos=pos,size=[width, height],pen=par['Color'])
+            roi = self.make_ROI2D(roi_type, index=newindex, pos=pos,size=[width, height],
+                                  pen=param['Color'], compute=param['process_data'])
 
         return roi
 
@@ -289,11 +291,11 @@ class ROIManager(QObject):
 
     def expand_roi_tree(self, roi,):
         # Expand roi tree when roi gets double selected
-        par = self.settings.child(*('ROIs', roi_format(roi.index)))
-        isExpanded = not par.opts['expanded']    
-        par.setOpts(expanded=isExpanded)                
+        param = self.settings.child(*('ROIs', roi_format(roi.index)))
+        isExpanded = not param.opts['expanded']
+        param.setOpts(expanded=isExpanded)
 
-    def make_ROI1D(self, index, pos, **kwargs):
+    def make_ROI1D(self, index, pos, compute=True, **kwargs):
         """Convenience function to make custom ROI_1D
 
         Args:
@@ -303,12 +305,12 @@ class ROIManager(QObject):
         Returns:
             roi: LinearROI
         """
-        roi = LinearROI(index=index, pos=pos,**kwargs)
+        roi = LinearROI(index=index, pos=pos, compute=compute, **kwargs)
         # roi.setZValue(-10)
         roi.setOpacity(0.2)
         return roi                    
 
-    def make_ROI2D(self, roi_type, index, pos, size, **kwargs):
+    def make_ROI2D(self, roi_type, index, pos, size, compute=True, **kwargs):
         """Convenience function to make custom ROI_2D
 
         Args:
@@ -322,13 +324,16 @@ class ROIManager(QObject):
         """
         if roi_type == 'RectROI':
             roi = RectROI(index=index, pos=pos,
-                          size=size, name=roi_format(index),**kwargs)
+                          size=size, name=roi_format(index),
+                          compute=compute, **kwargs)
         elif roi_type == 'EllipseROI':
             roi = EllipseROI(index=index, pos=pos,
-                             size=size, name=roi_format(index),**kwargs)
+                             size=size, name=roi_format(index),
+                             compute=compute, **kwargs)
         elif roi_type == 'CircularROI':
             roi = CircularROI(index=index, pos=pos,
-                              size=size, name=roi_format(index),**kwargs)
+                              size=size, name=roi_format(index),
+                              compute=compute, **kwargs)
 
         return roi
     

--- a/src/pymodaq_gui/managers/roi_manager.py
+++ b/src/pymodaq_gui/managers/roi_manager.py
@@ -18,6 +18,7 @@ from pymodaq_gui.managers.action_manager import QAction
 
 from pymodaq_utils.utils import plot_colors
 from pymodaq_utils.logger import get_module_name, set_logger
+from pymodaq_utils.config import Config
 from pymodaq_gui.config_saver_loader import get_set_roi_path
 from pymodaq_gui.utils import select_file
 from pymodaq_gui.plotting.items.roi import RectROI,LinearROI,EllipseROI,CircularROI,ROI
@@ -32,8 +33,7 @@ data_processors = DataProcessorFactory()
 
 roi_path = get_set_roi_path()
 logger = set_logger(get_module_name(__file__))
-translate = QtCore.QCoreApplication.translate
-
+config = Config()
 
 ROI_NAME_PREFIX = 'ROI_'
 ROI2D_TYPES = ['RectROI', 'EllipseROI', 'CircularROI']
@@ -95,6 +95,8 @@ class ROIScalableGroup(GroupParameter):
     def make_ROIParam2D(roi_type, index):
             children = []    
             children.extend([{'title': 'Type', 'name': 'roi_type', 'type': 'list', 'value': roi_type, 'limits':['RectROI','EllipseROI','CircularROI'], 'readonly': False,}])
+            children.append({'title': 'Process data', 'name': 'process_data', 'type': 'led_push',
+                             'value': config.get(('plotting', 'process_roi'), True),})
             children.extend(ROIScalableGroup.makeChannelsParam('2D'))
             children.extend(ROIScalableGroup.makeMathParam('2D'))
             children.extend(ROIScalableGroup.makeDisplayParam(index))
@@ -116,7 +118,9 @@ class ROIScalableGroup(GroupParameter):
 
     @staticmethod    
     def make_ROIParam1D(roi_type, index):
-            children = []    
+            children = []
+            children.append({'title': 'Process data', 'name': 'process_data', 'type': 'led_push',
+                             'value': config.get(('plotting', 'process_roi'), True),})
             children.extend(ROIScalableGroup.makeChannelsParam('1D'))
             children.extend(ROIScalableGroup.makeMathParam('1D'))
             children.extend(ROIScalableGroup.makeDisplayParam(index))
@@ -277,7 +281,7 @@ class ROIManager(QObject):
         # Updating tree
         self.update_roi_tree(roi)
         # Adding to dictionnary
-        self.ROIs[roi.key()]=roi 
+        self.ROIs[roi.key()] = roi
         # Adding to viewer
         self.viewer_widget.plotItem.addItem(roi)  
         # Emitting signal
@@ -288,7 +292,6 @@ class ROIManager(QObject):
         par = self.settings.child(*('ROIs', roi_format(roi.index)))
         isExpanded = not par.opts['expanded']    
         par.setOpts(expanded=isExpanded)                
-
 
     def make_ROI1D(self, index, pos, **kwargs):
         """Convenience function to make custom ROI_1D
@@ -319,13 +322,13 @@ class ROIManager(QObject):
         """
         if roi_type == 'RectROI':
             roi = RectROI(index=index, pos=pos,
-                                size=size, name=roi_format(index),**kwargs)
+                          size=size, name=roi_format(index),**kwargs)
         elif roi_type == 'EllipseROI':
             roi = EllipseROI(index=index, pos=pos,
-                                size=size, name=roi_format(index),**kwargs)
+                             size=size, name=roi_format(index),**kwargs)
         elif roi_type == 'CircularROI':
             roi = CircularROI(index=index, pos=pos,
-                                    size=size, name=roi_format(index),**kwargs)
+                              size=size, name=roi_format(index),**kwargs)
 
         return roi
     
@@ -346,7 +349,7 @@ class ROIManager(QObject):
         self.remove_ROI_signal.emit(roi.key())
         self.emit_colors()
 
-    def copy_ROI(self, roi:ROI):
+    def copy_ROI(self, roi: ROI):
         """Method to copy a ROI and add it to the parameter tree and to the viewer widget
         The method extracts the parameters of the copied ROI, create a new parameter, a new ROI and update it with the settings from the copied parameter
         Args:
@@ -388,7 +391,7 @@ class ROIManager(QObject):
                 param.setValue(dict(all_items=channels,
                         selected=channels))   
                     
-    def update_roi(self, roi:ROI, param):
+    def update_roi(self, roi: ROI, param: Parameter):
         par = self.get_parameter(roi)
         roi.signalBlocker.reblock()
         parent_name = param.parent().opts['name']
@@ -433,6 +436,8 @@ class ROIManager(QObject):
         elif param.name() == 'height':
             size = roi.size()
             roi.setSize((size[0], param.value()))
+        elif param.name() == 'process_data':
+            roi.compute = param.value()
 
         self.update_roi_tree(roi)
         roi.signalBlocker.unblock()

--- a/src/pymodaq_gui/plotting/items/roi.py
+++ b/src/pymodaq_gui/plotting/items/roi.py
@@ -1,4 +1,4 @@
-
+from abc import abstractmethod
 from typing import TYPE_CHECKING, List, Tuple, Union
 
 import numpy as np
@@ -29,30 +29,99 @@ def roi_format(index):
     return f'{ROI_NAME_PREFIX}{index:02d}'
 
 
-class ROI(pgROI):
+class ROIMixin(QtCore.QObject):
     index_signal = Signal(int)
-    sigCopyRequested = Signal(object)
-    sigDoubleClicked = Signal(object,object)
 
-    def __init__(self, *args, index=0, name='roi', **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, index=0, name='roi'):
+        super().__init__()
         self.name = name
         self.index = index
+        self._compute = True
+        self.menu = None
+
         self.signalBlocker = QSignalBlocker(self)
         self.signalBlocker.unblock()
         self._clipboard = QtGui.QGuiApplication.clipboard()
 
+    def emit_index_signal(self):
+        self.index_signal.emit(self.index)
+
+    @abstractmethod
+    def mouseClickEvent(self, ev):
+        ...
+
+    @abstractmethod
+    def color(self):
+        ...
+
+    @abstractmethod
+    def getMenu(self):
+        ...
+
     def _emitCopyRequest(self):
         self.sigCopyRequested.emit(self)
 
+    def mouseDoubleClickEvent(self, ev):
+        if ev.button() == QtCore.Qt.MouseButton.LeftButton:
+            ev.accept()
+            self.sigDoubleClicked.emit(self, ev)
+
+    @abstractmethod
+    def copy_clipboard(self):
+        ...
+
+    @abstractmethod
+    def center(self):
+        ...
+
+    @abstractmethod
+    def width(self):
+        ...
+    @abstractmethod
+    def height(self):
+        ...
+
+    def key(self) -> str:
+        return roi_format(self.index)
+
+    def type(self) -> str:
+        return type(self).__name__
+
+    def doShow(self, status: bool = True):
+        if status:
+            self.show()
+        else:
+            self.hide()
+
+    @property
+    def compute(self):
+        return self._compute
+
+    @compute.setter
+    def compute(self, compute: bool = True):
+        self._compute = compute
+
+
+class ROI(pgROI, ROIMixin):
+    sigCopyRequested = Signal(object)
+    sigDoubleClicked = Signal(object, object)
+    sigRemoveRequested = Signal(object)
+
+    def __init__(self, *args, index=0, name='roi', **kwargs):
+        ROIMixin.__init__(self, index=index, name=name)
+        pgROI.__init__(self, *args, **kwargs)
+
+    def getMenu(self):
+        if self.menu is None:
+            self.menu = QtWidgets.QMenu()
+            self.menu.setTitle(translate("ROI", "ROI"))
+            self.menu.addAction('Copy ROI to clipboard', self.copy_clipboard)
+            self.menu.addAction("Copy ROI", self._emitCopyRequest)
+            self.menu.addAction("Remove ROI", self._emitRemoveRequest)
+        return self.menu
+
     def contextMenuEnabled(self):
         return True
-    
-    def mouseClickEvent(self,ev):
-        super().mouseClickEvent(ev)
-        if ev.button() == QtCore.Qt.MouseButton.MiddleButton:
-            ev.accept()
-            self._emitRemoveRequest()
 
     def raiseContextMenu(self, ev):
         menu = self.getMenu()
@@ -60,26 +129,23 @@ class ROI(pgROI):
         pos = ev.screenPos()
         menu.popup(QtCore.QPoint(int(pos.x()), int(pos.y())))
 
-    def getMenu(self):
-        if self.menu is None:
-            self.menu = QtWidgets.QMenu()
-            self.menu.setTitle(translate("ROI", "ROI"))
-            self.menu.addAction('Copy ROI to clipboard', self.copy_clipboard)            
-            self.menu.addAction("Copy ROI",self._emitCopyRequest)
-            self.menu.addAction("Remove ROI",self._emitRemoveRequest)       
-        return self.menu
-    
     def contextMenuEvent(self, event):
         if self.menu is not None:
             self.menu.exec(event.screenPos())
 
-    def mouseDoubleClickEvent(self,ev):
-        if ev.button() == QtCore.Qt.MouseButton.LeftButton:
+    def mouseClickEvent(self, ev):
+        super().mouseClickEvent(ev)
+        if ev.button() == QtCore.Qt.MouseButton.RightButton and self.contextMenuEnabled():
+            self.raiseContextMenu(ev)
             ev.accept()
-            self.sigDoubleClicked.emit(self,ev)
-
-    def emit_index_signal(self):
-        self.index_signal.emit(self.index)
+        elif self.acceptedMouseButtons() & ev.button():
+            ev.accept()
+            self.sigClicked.emit(self, ev)
+        elif ev.button() == QtCore.Qt.MouseButton.MiddleButton:
+            ev.accept()
+            self._emitRemoveRequest()
+        else:
+            ev.ignore()
 
     @property
     def color(self):
@@ -103,17 +169,6 @@ class ROI(pgROI):
     def height(self) -> float:
         return self.size().y()
 
-    def key(self) -> str:
-        return roi_format(self.index)
-    
-    def type(self) -> str:
-        return type(self).__name__    
-    
-    def doShow(self,status,):
-        if status:
-            self.show()
-        else:
-            self.hide()
 
 class ROIBrushable(ROI):
     def __init__(self, brush=None, *args, **kwargs):
@@ -144,34 +199,36 @@ class ROIBrushable(ROI):
         # p.restore()
 
 
-class LinearROI(pgLinearROI):
-    index_signal = Signal(int)
+class LinearROI(pgLinearROI, ROIMixin):
     sigCopyRequested = Signal(object)
     sigDoubleClicked = Signal(object,object)
     sigRemoveRequested = Signal(object)
 
     def __init__(self, index=0, pos=[0, 10], name = 'roi', **kwargs):
-        super().__init__(values=pos, **kwargs)
-        self.name = name
-        self.index = index
-        self.signalBlocker = QSignalBlocker(self)
-        self.menu = None
-        self._clipboard = QtGui.QGuiApplication.clipboard()
+        ROIMixin.__init__(self, index=index, name=name)
+        pgLinearROI.__init__(self, values=pos, **kwargs)
 
-    def copy_clipboard(self):
-        info = plot_utils.RoiInfo.info_from_linear_roi(self)
-        self._clipboard.setText(str(info.to_slices()))
-
-
-    def _emitRemoveRequest(self):
-        self.sigRemoveRequested.emit(self)
-
-    def _emitCopyRequest(self):
-        self.sigCopyRequested.emit(self)
+    def getMenu(self):
+        if self.menu is None:
+            self.menu = QtWidgets.QMenu()
+            self.menu.setTitle(translate("ROI", "ROI"))
+            self.menu.addAction('Copy ROI to clipboard', self.copy_clipboard)
+            self.menu.addAction("Copy ROI", self._emitCopyRequest)
+            self.menu.addAction("Remove ROI", self._emitRemoveRequest)
+        return self.menu
 
     def contextMenuEnabled(self):
         return True
-    
+
+    def raiseContextMenu(self, ev):
+        menu = self.getMenu()
+        menu = self.scene().addParentContextMenus(self, menu, ev)
+        pos = ev.screenPos()
+        menu.popup(QtCore.QPoint(int(pos.x()), int(pos.y())))
+
+    def contextMenuEvent(self, event):
+        if self.menu is not None:
+            self.menu.exec(event.screenPos())
 
     def mouseClickEvent(self, ev):
         super().mouseClickEvent(ev)
@@ -187,33 +244,9 @@ class LinearROI(pgLinearROI):
         else:
             ev.ignore()
 
-
-    def raiseContextMenu(self, ev):
-        menu = self.getMenu()
-        menu = self.scene().addParentContextMenus(self, menu, ev)
-        pos = ev.screenPos()
-        menu.popup(QtCore.QPoint(int(pos.x()), int(pos.y())))
-
-    def getMenu(self):
-        if self.menu is None:
-            self.menu = QtWidgets.QMenu()
-            self.menu.setTitle(translate("ROI", "ROI"))
-            self.menu.addAction('Copy ROI to clipboard', self.copy_clipboard)            
-            self.menu.addAction("Copy ROI",self._emitCopyRequest)
-            self.menu.addAction("Remove ROI",self._emitRemoveRequest)       
-        return self.menu
-    
-    def contextMenuEvent(self, event):
-        if self.menu is not None:
-            self.menu.exec(event.screenPos())
-
-    def mouseDoubleClickEvent(self,ev):
-        if ev.button() == QtCore.Qt.MouseButton.LeftButton:
-            ev.accept()
-            self.sigDoubleClicked.emit(self,ev)
-
-    def emit_index_signal(self):
-        self.index_signal.emit(self.index)
+    def copy_clipboard(self):
+        info = plot_utils.RoiInfo.info_from_linear_roi(self)
+        self._clipboard.setText(str(info.to_slices()))
 
     def pos(self) -> Tuple[float, float]:
         return self.getRegion()
@@ -232,17 +265,7 @@ class LinearROI(pgLinearROI):
     def color(self):
         return self.brush.color()
 
-    def emit_index_signal(self):
-        self.index_signal.emit(self.index)
 
-    def key(self,):
-        return roi_format(self.index)
-    
-    def doShow(self,status,):
-        if status:
-            self.show()
-        else:
-            self.hide()
 class EllipseROI(ROI):
     """
     Elliptical ROI subclass with one scale handle and one rotation handle.

--- a/src/pymodaq_gui/plotting/items/roi.py
+++ b/src/pymodaq_gui/plotting/items/roi.py
@@ -32,11 +32,11 @@ def roi_format(index):
 class ROIMixin(QtCore.QObject):
     index_signal = Signal(int)
 
-    def __init__(self, index=0, name='roi'):
+    def __init__(self, index=0, name='roi', compute=True):
         super().__init__()
         self.name = name
         self.index = index
-        self._compute = True
+        self._compute = compute
         self.menu = None
 
         self.signalBlocker = QSignalBlocker(self)
@@ -107,8 +107,8 @@ class ROI(pgROI, ROIMixin):
     sigDoubleClicked = Signal(object, object)
     sigRemoveRequested = Signal(object)
 
-    def __init__(self, *args, index=0, name='roi', **kwargs):
-        ROIMixin.__init__(self, index=index, name=name)
+    def __init__(self, *args, index=0, name='roi', compute=True, **kwargs):
+        ROIMixin.__init__(self, index=index, name=name, compute=compute)
         pgROI.__init__(self, *args, **kwargs)
 
     def getMenu(self):
@@ -204,8 +204,8 @@ class LinearROI(pgLinearROI, ROIMixin):
     sigDoubleClicked = Signal(object,object)
     sigRemoveRequested = Signal(object)
 
-    def __init__(self, index=0, pos=[0, 10], name = 'roi', **kwargs):
-        ROIMixin.__init__(self, index=index, name=name)
+    def __init__(self, index=0, pos=[0, 10], name = 'roi', compute=True, **kwargs):
+        ROIMixin.__init__(self, index=index, name=name, compute=compute)
         pgLinearROI.__init__(self, values=pos, **kwargs)
 
     def getMenu(self):

--- a/src/pymodaq_gui/plotting/utils/filter.py
+++ b/src/pymodaq_gui/plotting/utils/filter.py
@@ -244,14 +244,15 @@ class Filter1DFromRois(Filter):
                 self.update_axis(axis)
             if data is not None:                                
                 for roi_key, roi in self._ROIs.items():
-                    sub_data = data.deepcopy()                
-                    labels = self._roi_settings['ROIs', roi_key, 'use_channel']['selected']
-                    if labels:
-                        sub_data.data = [sub_data[sub_data.labels.index(label)] for label in labels]
-                        sub_data.labels = [label for label in labels]                
-                    dte_tmp = self.get_data_from_roi(roi, self._roi_settings.child('ROIs', roi_key),
-                                                                    sub_data)
-                    dte.append(dte_tmp)
+                    if roi.compute:
+                        sub_data = data.deepcopy()
+                        labels = self._roi_settings['ROIs', roi_key, 'use_channel']['selected']
+                        if labels:
+                            sub_data.data = [sub_data[sub_data.labels.index(label)] for label in labels]
+                            sub_data.labels = [label for label in labels]
+                        dte_tmp = self.get_data_from_roi(roi, self._roi_settings.child('ROIs', roi_key),
+                                                                        sub_data)
+                        dte.append(dte_tmp)
         except Exception as e:
             logger.warning(f'Issue with the ROI: {str(e)}')
         return dte
@@ -308,16 +309,17 @@ class Filter2DFromRois(Filter):
             try:
                 labels = []
                 for roi_key, roi in self._ROIs.items():
-                    labels = self._roi_settings['ROIs', roi_key, 'use_channel']['selected']
-                    sub_data = dwa.deepcopy()
-                    if labels:
-                        sub_data.data = [dwa[dwa.labels.index(label)] for label in labels]
-                        sub_data.labels = [label for label in labels]
-                        dte_temp = self.get_xydata_from_roi(roi, sub_data,
-                                                                self._roi_settings['ROIs',
-                                                                roi_key, 'math_function'])
+                    if roi.compute:
+                        labels = self._roi_settings['ROIs', roi_key, 'use_channel']['selected']
+                        sub_data = dwa.deepcopy()
+                        if labels:
+                            sub_data.data = [dwa[dwa.labels.index(label)] for label in labels]
+                            sub_data.labels = [label for label in labels]
+                            dte_temp = self.get_xydata_from_roi(roi, sub_data,
+                                                                    self._roi_settings['ROIs',
+                                                                    roi_key, 'math_function'])
 
-                        dte.append(dte_temp)
+                            dte.append(dte_temp)
             except Exception as e:
                 logger.warning(f'Issue with the ROI: {str(e)}')
         return dte


### PR DESCRIPTION
meant to replace #76 

#76 was acting on the roi lineouts displayed on the viewers or not and was generating issues with labelling and some data still lingering within the lineouts viewers. This PR is acting directly on the filtering of data or not using a new property of the roi called compute. This means that at first data are displayed, then updated or not depending on the status of the process data bollean within the roi parameter tree related to the compute bollean property of the roi.

It makes programming this feature simpler while still doing what was expected in #76 

I also refactored some methods and attributes of ROI and LinearROI (within a mixin class) that should have the same interface to work smoothly within pymodaq.