### PR TITLE
in some particular case the loaded config may be for other couples of…

### DIFF
--- a/src/pymodaq_gui/config_saver_loader.py
+++ b/src/pymodaq_gui/config_saver_loader.py
@@ -74,7 +74,7 @@ class ConfigSaverLoader:
                 try:
                     child.setValue(self.config(
                         *path))  # first try to load the config including the actuators name
-                except ConfigError as e:
+                except (ConfigError, TypeError) as e:
                     pass
             else:
                 self.load_config(child)


### PR DESCRIPTION
… settings trying to set a value for the wrong type

the handling of the type error solve this

This issue appeared in the Adaptive extension after trying all the loss functions in 2D/1D