### PR TITLE
Adding a safe check to only set value if the parameter has value

### DIFF
--- a/src/pymodaq_gui/parameter/pymodaq_ptypes/list.py
+++ b/src/pymodaq_gui/parameter/pymodaq_ptypes/list.py
@@ -72,7 +72,7 @@ class ListParameterItem(ListParameterItem):
         w.setValue = self.setValue
         self.widget = w  # # needs to be set before limits are changed
         self.limitsChanged(self.param, self.param.opts['limits'])
-        if len(self.forward) > 0:
+        if len(self.forward) > 0 and self.param.hasValue():
             self.setValue(self.param.value())
         return w
 


### PR DESCRIPTION
Sometimes the initialization of a list parameter can failed if the parameter has no value attributed. 
This result in an error in the loading, the parameters after the fail are not being loaded.

In the initial version from pyqtgraph, the self.param.hasValue() was used as a check.

In this PR, I propose to add it too in pymodaq list parameter item.

