### PR TITLE
introduction of addMenu in GroupParameterItem induce a backcompatibility issue

### DIFF
--- a/src/pymodaq_gui/parameter/pymodaq_ptypes/group.py
+++ b/src/pymodaq_gui/parameter/pymodaq_ptypes/group.py
@@ -10,6 +10,8 @@ class GroupParameterItem(GroupParameterItem):
     """
 
     def __init__(self, param, depth):
+        if 'addMenu' in param.opts:
+            param.opts.pop('addList')
         super().__init__(param, depth)
 
         if 'addMenu' in param.opts:


### PR DESCRIPTION

if both addList (before) and addMenu (new) options are present, a ComboBox is loaded and raise an issue when trying to implement the Qmenu.

For this reason if both options are present the addMenu is prioritar and addList is removed. This creates a Qpushbutton with a Qmenu on it