### PR TITLE
Adding a default value to pop to avoid KeyError

### DIFF
--- a/src/pymodaq_gui/parameter/pymodaq_ptypes/group.py
+++ b/src/pymodaq_gui/parameter/pymodaq_ptypes/group.py
@@ -11,7 +11,7 @@ class GroupParameterItem(GroupParameterItem):
 
     def __init__(self, param, depth):
         if 'addMenu' in param.opts:
-            param.opts.pop('addList')
+            param.opts.pop('addList', None)
         super().__init__(param, depth)
 
         if 'addMenu' in param.opts:


### PR DESCRIPTION
The pop option used to check if addList is present with addMenu throws keyError if no addList is present.
This PR add a default value to avoid it.