### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
           
     steps:
-    - uses: actions/checkout@v4.2.2
+    - uses: actions/checkout@v5.0.0
     - name: Set up Python
-      uses: actions/setup-python@v5.6.0
+      uses: actions/setup-python@v6.0.0
       with:
         python-version: '3.11'
     - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,10 +40,10 @@ jobs:
         
 
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v5.0.0
  
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5.6.0
+        uses: actions/setup-python@v6.0.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -128,12 +128,12 @@ jobs:
     needs: tests # Ensure this job runs after all matrix jobs complete
     steps:
        # switch to badges branches to commit
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v5.0.0
         with:
           ref: badges
      
       - name: Download badges
-        uses: actions/download-artifact@v4.3.0
+        uses: actions/download-artifact@v5.0.0
 
       - name: Reorganize badges
         run: |
@@ -152,7 +152,7 @@ jobs:
           git commit  --allow-empty -m "Add/Update badge"
 
       - name: Push badges
-        uses: ad-m/github-push-action@v0.8.0
+        uses: ad-m/github-push-action@v1.0.0
         if: ${{ success() }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -163,10 +163,10 @@ jobs:
 
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v5.0.0
 
       - name: Download all coverage artifacts
-        uses: actions/download-artifact@v4.3.0
+        uses: actions/download-artifact@v5.0.0
         with:
           path: ./coverage-reports
 
@@ -187,7 +187,7 @@ jobs:
           coverage xml -i
 
       - name: Upload combined coverage report to Codecov
-        uses: codecov/codecov-action@v5.4.3
+        uses: codecov/codecov-action@v5.5.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v5.0.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v5.0.0](https://github.com/actions/checkout/releases/tag/v5.0.0)** on 2025-08-11T12:39:13Z
* **[actions/download-artifact](https://github.com/actions/download-artifact)** published a new release **[v5.0.0](https://github.com/actions/download-artifact/releases/tag/v5.0.0)** on 2025-08-05T21:38:42Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v6.0.0](https://github.com/actions/setup-python/releases/tag/v6.0.0)** on 2025-09-04T03:14:37Z
* **[ad-m/github-push-action](https://github.com/ad-m/github-push-action)** published a new release **[v1.0.0](https://github.com/ad-m/github-push-action/releases/tag/v1.0.0)** on 2025-09-12T17:47:29Z
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v5.5.1](https://github.com/codecov/codecov-action/releases/tag/v5.5.1)** on 2025-09-04T14:36:56Z
