### PR TITLE
Add y units to viewer0D and viewer1D

### DIFF
--- a/src/pymodaq_gui/plotting/data_viewers/viewer0D.py
+++ b/src/pymodaq_gui/plotting/data_viewers/viewer0D.py
@@ -108,7 +108,7 @@ class DataDisplayer(QObject):
             for ind in range(len(data)):
                 self._plot_items.append(pyqtgraph.PlotDataItem(pen=self.colors[ind]))
                 self._plotitem.addItem(self._plot_items[-1])
-                self.legend.addItem(self._plot_items[-1], data.labels[ind])
+                self.legend.addItem(self._plot_items[-1], f"{data.labels[ind]} ({data.units})")
                 max_line = pyqtgraph.InfiniteLine(angle=0,
                                                   pen=pyqtgraph.mkPen(color=self.colors[ind]['color'],
                                                                       style=Qt.DashLine))
@@ -287,7 +287,7 @@ def main():
     prog.get_action('show_data_as_list').trigger()
     for ind, data in enumerate(y1):
         prog.show_data(data_mod.DataRaw('mydata', data=[np.array([data]), np.array([y2[ind]])],
-                                        labels=['lab1', 'lab2']))
+                                        labels=['lab1', 'lab2'], units="V"))
         QtWidgets.QApplication.processEvents()
 
     sys.exit(app.exec_())

--- a/src/pymodaq_gui/plotting/data_viewers/viewer1D.py
+++ b/src/pymodaq_gui/plotting/data_viewers/viewer1D.py
@@ -173,7 +173,7 @@ class DataDisplayer(QObject):
             axis = self._plotitem.getAxis('bottom')
             axis.setLabel(text=_axis.label, units=_axis.units)
             axis = self._plotitem.getAxis('left')
-            axis.setLabel(text='', units='')
+            axis.setLabel(text='', units=dwa.units)
             self.legend.setVisible(True)
 
     def plot_with_scatter(self, with_scatter=True, symbol_size=5, symbol='o', color=None):
@@ -838,8 +838,8 @@ def main_xy():
     y2 = gauss1D(x, 120, 50, 2)
 
     QtWidgets.QApplication.processEvents()
-    data = DataRaw('mydata', data=[y1, y2],
-                   axes=[Axis('myaxis', 'units', data=x, index=0, spread_order=0)],
+    data = DataRaw('mydata', data=[y1, y2], units='m/s',
+                   axes=[Axis('myaxis', 's', data=x, index=0, spread_order=0)],
                    )
     data.plot('qt')
 


### PR DESCRIPTION
Addresses https://github.com/PyMoDAQ/PyMoDAQ/issues/653

Displays the unit set as the `unit` parameter of `DataWithAxes` objects and their children:
- `viewer0D`: as suffix to the label displayed in the legend
- `viewer1D`: on the left axis, along with the y-axis label

The examples packaged with these two viewers (by running them directly as Python scripts) were also updated to reflect these changes. 