### PR TITLE
Feature/search line edit

### DIFF
--- a/src/pymodaq_gui/examples/parameter_ex.py
+++ b/src/pymodaq_gui/examples/parameter_ex.py
@@ -154,7 +154,8 @@ class ParameterEx(ParameterManager):
             self.settings.child('numbers', 'linearslidefloat').setOpts(bounds=limits) # or like this!
 
     def options_changed(self, param, data: dict):
-        print(f'{param} option has been changed: {data}')
+        if data.get("visible", None) is None:
+            print(f'{param} option has been changed: {data}')
 
     def limits_changed(self, param, data):
         print(f'{param} limits have been changed: {data}')

--- a/src/pymodaq_gui/managers/parameter_manager.py
+++ b/src/pymodaq_gui/managers/parameter_manager.py
@@ -47,13 +47,54 @@ class ParameterTreeWidget(ActionManager):
         self.widget.layout().addWidget(self.collapsible_widget)
         self.widget.layout().addWidget(self.tree)        
         self.widget.layout().setContentsMargins(0, 0, 0, 0)
+        # Setup keyboard shortcuts
+        if "search" in action_list:
+            self._setup_search_shortcuts()
 
-    def setup_actions(self, action_list: tuple = ('save', 'update', 'load')):
+    def _setup_search_shortcuts(self):
+        """Setup keyboard shortcuts for search functionality"""
+        self.search_activate_shortcut = QtGui.QShortcut(
+            QtGui.QKeySequence("Ctrl+F"), self.widget
+        )
+        self.search_activate_shortcut.activated.connect(self.activate_search)
+
+        self.search_escape_shortcut = QtGui.QShortcut(
+            QtGui.QKeySequence("Esc"), self.widget
+        )
+        self.search_escape_shortcut.activated.connect(self.collapse_toolbar)
+
+    def activate_search(self):
+        """Show the collapsible widget and focus on the search field"""
+        # Expand the collapsible widget if it's collapsed
+        self.collapsible_widget.toggle_content()
+        # Get the search widget and set focus
+        search_widget:SearchLineEdit = self.get_action("search_settings")
+        if search_widget:
+            search_widget.setFocus()
+            search_widget.selectAll()  # Optional: select all text for easy replacement
+
+    def collapse_toolbar(self):
+        """Collapse toolbar"""
+        if self.collapsible_widget.is_expanded:
+            self.collapsible_widget.toggle_content()
+            search_widget: SearchLineEdit = self.get_action("search_settings")
+            if search_widget:
+                search_widget.clearFocus()
+
+    def setup_actions(self, action_list: tuple = ('search', 'save', 'update', 'load')):
         """
         See Also
         --------
         ActionManager.add_action
         """
+        # Search action
+        self.add_widget(
+            "search_settings",
+            klass=SearchLineEdit(self.toolbar, debounce_ms=200),
+            visible="search" in action_list,
+        )
+        self.toolbar.addSeparator()
+
         # Saving action
         self.add_action('save_settings', 'Save Settings', 'saveTree',
                         "Save current settings in an xml file", 
@@ -88,8 +129,9 @@ class ParameterManager:
     params = []
 
     def __init__(self, settings_name: Optional[str] = None,
-                 action_list: tuple = ('save', 'update', 'load'),
+                 action_list: tuple = ('search', 'save', 'update', 'load'),
                  ):
+        self._current_filter_text = ""        
         if settings_name is None:
             settings_name = self.settings_name
         # create a settings tree to be shown eventually in a dock
@@ -100,7 +142,16 @@ class ParameterManager:
         self._settings_tree.get_action(f'save_settings').connect_to(self.save_settings_slot)
         self._settings_tree.get_action(f'update_settings').connect_to(self.update_settings_slot)
         self._settings_tree.get_action(f'load_settings').connect_to(self.load_settings_slot)
-                                                                        
+        # Add this line to connect the search widget
+        if "search" in action_list:
+            self._settings_tree.get_action("search_settings").searchTextChanged.connect(
+                self.search_settings_slot
+            )
+        self._settings_tree.collapsible_widget.toggled_signal.connect(
+            self.on_toolbar_toggled
+        )
+
+
         self.settings = Parameter.create(name=settings_name, type='group', children=self.params,
                                          showTop=False)  # create a Parameter
         # object containing the settings defined in the preamble
@@ -241,8 +292,7 @@ class ParameterManager:
             a tuple of some other objects
 
         """
-        pass
-
+        pass      
 
     def save_settings_slot(self, file_path: Path = None):
         """ Method to save the current settings using a xml file extension.
@@ -312,3 +362,24 @@ class ParameterManager:
             else:
                 logger.info(f'The loaded settings from {file_path} do not match the current settings structure and cannot be applied.')
 
+    def _apply_filter(self, text: str):
+        """Apply filter to parameter tree with optimized updates"""
+        with self.settings.treeChangeBlocker():
+            filter_parameter_tree(self.settings, text)
+
+
+    def search_settings_slot(self, text: str = ""):
+        """Handle search text changes"""
+        self._current_filter_text = text
+        self._apply_filter(text)
+
+    def on_toolbar_toggled(self):
+        """Handle toolbar expand/collapse - reapply or clear filter"""
+        search_widget = self._settings_tree.get_action("search_settings")
+
+        if search_widget:
+            if self._settings_tree.collapsible_widget.is_expanded:
+                self._current_filter_text = search_widget.text()
+            else:
+                self._current_filter_text = ""
+            self._apply_filter(self._current_filter_text)

--- a/src/pymodaq_gui/managers/parameter_manager.py
+++ b/src/pymodaq_gui/managers/parameter_manager.py
@@ -18,8 +18,31 @@ logger = set_logger(get_module_name(__file__))
 
 
 class ParameterTreeWidget(ActionManager):
+    """Widget that combines a ParameterTree with a toolbar for parameter management.
 
-    def __init__(self, action_list: tuple = ('save', 'update', 'load')):
+    This class provides a complete UI for managing parameters, including actions for
+    saving, loading, updating settings, and searching through the parameter tree.
+    The toolbar can be collapsed to save screen space.
+
+    Parameters
+    ----------
+    action_list : tuple, optional
+        Tuple of action names to include in the toolbar. Valid values are:
+        'save', 'update', 'load', and 'search'. Default is ('save', 'update', 'load').
+
+    Attributes
+    ----------
+    widget : QtWidgets.QWidget
+        The main widget containing the toolbar and parameter tree
+    tree : ParameterTree
+        The parameter tree for displaying and editing parameters
+    toolbar : QtWidgets.QToolBar
+        Toolbar containing action buttons for parameter management
+    collapsible_widget : CollapsibleWidget
+        Widget that allows the toolbar to be collapsed/expanded
+    """
+
+    def __init__(self, action_list: tuple = ("save", "update", "load")):
         super().__init__()
 
         self.widget = QtWidgets.QWidget()
@@ -29,11 +52,13 @@ class ParameterTreeWidget(ActionManager):
         self.set_toolbar(toolbar)
         self.tree: ParameterTree = ParameterTree()
 
-        self.widget.header = self.tree.header  # for back-compatibility, widget behave a bit like a ParameterTree
+        self.widget.header = (
+            self.tree.header
+        )  # for back-compatibility, widget behave a bit like a ParameterTree
         self.widget.listAllItems = self.tree.listAllItems  # for back-compatibility
 
-        #self.tree.setMinimumWidth(150)
-        #self.tree.setMinimumHeight(300)
+        # self.tree.setMinimumWidth(150)
+        # self.tree.setMinimumHeight(300)
         toggle_top = QtWidgets.QPushButton("▼")
         self.collapsible_widget = CollapsibleWidget(
             toggle_widget=toggle_top,
@@ -43,16 +68,21 @@ class ParameterTreeWidget(ActionManager):
         )
 
         # Making the buttons
-        self.setup_actions(action_list) 
+        self.setup_actions(action_list)
         self.widget.layout().addWidget(self.collapsible_widget)
-        self.widget.layout().addWidget(self.tree)        
+        self.widget.layout().addWidget(self.tree)
         self.widget.layout().setContentsMargins(0, 0, 0, 0)
         # Setup keyboard shortcuts
         if "search" in action_list:
             self._setup_search_shortcuts()
 
     def _setup_search_shortcuts(self):
-        """Setup keyboard shortcuts for search functionality"""
+        """Setup keyboard shortcuts for search functionality.
+
+        Creates two keyboard shortcuts:
+        - Ctrl+F: Activates the search field and expands the toolbar if collapsed
+        - Esc: Collapses the toolbar and removes focus from the search field
+        """
         self.search_activate_shortcut = QtGui.QShortcut(
             QtGui.QKeySequence("Ctrl+F"), self.widget
         )
@@ -64,28 +94,47 @@ class ParameterTreeWidget(ActionManager):
         self.search_escape_shortcut.activated.connect(self.collapse_toolbar)
 
     def activate_search(self):
-        """Show the collapsible widget and focus on the search field"""
+        """Show the collapsible widget and focus on the search field.
+
+        Expands the toolbar if it's currently collapsed, then sets focus to the
+        search field and selects all existing text for easy replacement.
+        """
         # Expand the collapsible widget if it's collapsed
         self.collapsible_widget.toggle_content()
         # Get the search widget and set focus
-        search_widget:SearchLineEdit = self.get_action("search_settings")
+        search_widget: SearchLineEdit = self.get_action("search_settings")
         if search_widget:
             search_widget.setFocus()
             search_widget.selectAll()  # Optional: select all text for easy replacement
 
     def collapse_toolbar(self):
-        """Collapse toolbar"""
+        """Collapse the toolbar and clear search field focus.
+
+        If the toolbar is currently expanded, this method collapses it and
+        removes focus from the search field, effectively canceling the search mode.
+        """
         if self.collapsible_widget.is_expanded:
             self.collapsible_widget.toggle_content()
             search_widget: SearchLineEdit = self.get_action("search_settings")
             if search_widget:
                 search_widget.clearFocus()
 
-    def setup_actions(self, action_list: tuple = ('search', 'save', 'update', 'load')):
-        """
+    def setup_actions(self, action_list: tuple = ("search", "save", "update", "load")):
+        """Create and configure toolbar actions based on the provided action list.
+
+        Parameters
+        ----------
+        action_list : tuple, optional
+            Tuple of action names to include. Valid values are:
+            - 'search': Adds a search field with debounced text input
+            - 'save': Adds a button to save settings to an XML file
+            - 'update': Adds a button to update settings from an XML file
+            - 'load': Adds a button to load settings from an XML file
+            Default is ('search', 'save', 'update', 'load').
+
         See Also
         --------
-        ActionManager.add_action
+        ActionManager.add_action : Base class method for adding actions
         """
         # Search action
         self.add_widget(
@@ -96,52 +145,102 @@ class ParameterTreeWidget(ActionManager):
         self.toolbar.addSeparator()
 
         # Saving action
-        self.add_action('save_settings', 'Save Settings', 'saveTree',
-                        "Save current settings in an xml file", 
-                        visible = 'save' in action_list)
+        self.add_action(
+            "save_settings",
+            "Save Settings",
+            "saveTree",
+            "Save current settings in an xml file",
+            visible="save" in action_list,
+        )
         # Update action
-        self.add_action('update_settings', 'Update Settings', 'updateTree',
-                        "Update the settings from an xml file, the settings structure loaded must be identical to the current one",
-                        visible = 'update' in action_list)                
+        self.add_action(
+            "update_settings",
+            "Update Settings",
+            "updateTree",
+            "Update the settings from an xml file, the settings structure loaded must be identical to the current one",
+            visible="update" in action_list,
+        )
         # Load action
-        self.add_action('load_settings', 'Load Settings', 'openTree',
-                        "Load current settings from an xml file, the current settings structure is erased and is replaced by the new one",
-                         visible = 'load' in action_list)
+        self.add_action(
+            "load_settings",
+            "Load Settings",
+            "openTree",
+            "Load current settings from an xml file, the current settings structure is erased and is replaced by the new one",
+            visible="load" in action_list,
+        )
 
 
 class ParameterManager:
-    """Class dealing with Parameter and ParameterTree
+    """Class dealing with Parameter and ParameterTree management.
+
+    This class provides a complete parameter management system with support for
+    saving, loading, and updating parameters from XML files. It also includes
+    search functionality and callback methods for responding to parameter changes.
+
+    Parameters
+    ----------
+    settings_name : str, optional
+        The name to assign to the root Parameter object. If None, uses the
+        class attribute 'settings_name'. Default is None.
+    action_list : tuple, optional
+        Tuple of action names to include in the toolbar. Valid values are:
+        'search', 'save', 'update', and 'load'.
+        Default is ('search', 'save', 'update', 'load').
 
     Attributes
     ----------
-    params: list of dicts
-        Defining the Parameter tree like structure
-    settings_name: str
-        The particular name to give to the object parent Parameter (self.settings)
-    settings: Parameter
-        The higher level (parent) Parameter
-    settings_tree: QWidget
-        widget Holding a ParameterTree and a toolbar for interacting with the tree
-    tree: ParameterTree
-        the underlying ParameterTree
+    params : list of dicts
+        Class attribute defining the Parameter tree structure. Should be overridden
+        in subclasses to define the specific parameter hierarchy.
+    settings_name : str
+        The particular name given to the root Parameter object (self.settings)
+    settings : Parameter
+        The root Parameter object containing all parameter definitions
+    settings_tree : QWidget
+        Widget holding a ParameterTree and a toolbar for interacting with the tree
+    tree : ParameterTree
+        The underlying ParameterTree widget for displaying parameters
+
+    Examples
+    --------
+    >>> class MyManager(ParameterManager):
+    ...     settings_name = 'my_settings'
+    ...     params = [
+    ...         {'title': 'Main:', 'name': 'main_settings', 'type': 'group', 'children': [
+    ...             {'title': 'Value:', 'name': 'value', 'type': 'int', 'value': 0},
+    ...         ]},
+    ...     ]
+    ...
+    ...     def value_changed(self, param):
+    ...         if param.name() == 'value':
+    ...             print(f'Value changed to: {param.value()}')
     """
-    settings_name = 'custom_settings'
+
+    settings_name = "custom_settings"
     params = []
 
-    def __init__(self, settings_name: Optional[str] = None,
-                 action_list: tuple = ('search', 'save', 'update', 'load'),
-                 ):
-        self._current_filter_text = ""        
+    def __init__(
+        self,
+        settings_name: Optional[str] = None,
+        action_list: tuple = ("search", "save", "update", "load"),
+    ):
+        self._current_filter_text = ""
         if settings_name is None:
             settings_name = self.settings_name
         # create a settings tree to be shown eventually in a dock
         # object containing the settings defined in the preamble
         # create a settings tree to be shown eventually in a dock
         self._settings_tree = ParameterTreeWidget(action_list)
-        
-        self._settings_tree.get_action(f'save_settings').connect_to(self.save_settings_slot)
-        self._settings_tree.get_action(f'update_settings').connect_to(self.update_settings_slot)
-        self._settings_tree.get_action(f'load_settings').connect_to(self.load_settings_slot)
+
+        self._settings_tree.get_action(f"save_settings").connect_to(
+            self.save_settings_slot
+        )
+        self._settings_tree.get_action(f"update_settings").connect_to(
+            self.update_settings_slot
+        )
+        self._settings_tree.get_action(f"load_settings").connect_to(
+            self.load_settings_slot
+        )
         # Add this line to connect the search widget
         if "search" in action_list:
             self._settings_tree.get_action("search_settings").searchTextChanged.connect(
@@ -151,230 +250,496 @@ class ParameterManager:
             self.on_toolbar_toggled
         )
 
-
-        self.settings = Parameter.create(name=settings_name, type='group', children=self.params,
-                                         showTop=False)  # create a Parameter
+        self.settings = Parameter.create(
+            name=settings_name, type="group", children=self.params, showTop=False
+        )  # create a Parameter
         # object containing the settings defined in the preamble
-        self._settings_tree.tree.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeToContents)
+        self._settings_tree.tree.header().setSectionResizeMode(
+            QtWidgets.QHeaderView.ResizeToContents
+        )
 
     @property
     def settings_tree(self):
+        """QWidget: The main widget containing the parameter tree and toolbar."""
         return self._settings_tree.widget
 
     @property
     def tree(self):
+        """ParameterTree: The underlying parameter tree widget."""
         return self._settings_tree.tree
 
     @property
     def settings(self) -> Parameter:
+        """Parameter: The root parameter object containing all settings."""
         return self._settings
 
     @settings.setter
     def settings(self, settings: Union[Parameter, List[Dict[str, str]], Path]):
-        settings = self.create_parameter(settings)
-        self._settings = settings
-        self.tree.setParameters(self._settings, showTop=False)  # load the tree with this parameter object
-        self._settings.sigTreeStateChanged.connect(self.parameter_tree_changed)
-
-    @staticmethod
-    def create_parameter(settings: Union[Parameter, List[Dict[str, str]], Path]) -> Parameter:
-
-        if isinstance(settings, List):
-            _settings = Parameter.create(title='Settings', name='settings', type='group',
-                                         children=settings, showTop=False)
-        elif isinstance(settings, Path) or isinstance(settings, str):
-            settings = Path(settings)
-            _settings = Parameter.create(title='Settings', name='settings',
-                                         type='group', showTop=False,
-                                         children=ioxml.XML_file_to_parameter(str(settings)))
-        elif isinstance(settings, Parameter):
-            _settings = Parameter.create(title='Settings', name=settings.name(),
-                                         type='group', showTop=False)
-            _settings.restoreState(settings.saveState())
-        else:
-            raise TypeError(f'Cannot create Parameter object from {settings}')
-        return _settings
-
-    def parameter_tree_changed(self, param, changes):
-        for param, change, data in changes:
-            path = self._settings.childPath(param)
-            if change == 'childAdded':
-                self.child_added(param, data)
-
-            elif change == 'value':
-                self.value_changed(param)
-
-            elif change == 'parent':
-                self.param_deleted(param)
-
-            elif change == 'options':
-                self.options_changed(param, data)
-
-            elif change == 'limits':
-                self.limits_changed(param, data)
-
-    def value_changed(self, param: Parameter):
-        """Non-mandatory method  to be subclassed for actions to perform (methods to call) when one of the param's
-        value in self._settings is changed
-
-        For this to be triggered, the Parameter method: **setValue** should be used
+        """Set the settings parameter from various input types.
 
         Parameters
         ----------
-        param: Parameter
-            the parameter whose value just changed
+        settings : Parameter, list of dict, or Path
+            The settings to load. Can be:
+            - A Parameter object
+            - A list of dictionaries defining parameter structure
+            - A Path to an XML file containing saved parameters
+        """
+        settings = self.create_parameter(settings)
+        self._settings = settings
+        self.tree.setParameters(
+            self._settings, showTop=False
+        )  # load the tree with this parameter object
+        self._settings.sigTreeStateChanged.connect(self.parameter_tree_changed)
+
+    @staticmethod
+    def create_parameter(
+        settings: Union[Parameter, List[Dict[str, str]], Path],
+    ) -> Parameter:
+        """Create a Parameter object from various input types.
+
+        Parameters
+        ----------
+        settings : Parameter, list of dict, Path, or str
+            The settings to convert. Can be:
+            - A Parameter object (creates a copy)
+            - A list of dictionaries defining parameter structure
+            - A Path or string pointing to an XML file with saved parameters
+
+        Returns
+        -------
+        Parameter
+            A new Parameter object created from the input settings
+
+        Raises
+        ------
+        TypeError
+            If settings is not one of the supported types
 
         Examples
         --------
-        >>> if param.name() == 'do_something':
-        >>>     if param.value():
-        >>>         print('Do something')
-        >>>         self.settings.child('main_settings', 'something_done').setValue(False)
+        >>> params_list = [{'title': 'Value', 'name': 'val', 'type': 'int', 'value': 5}]
+        >>> param = ParameterManager.create_parameter(params_list)
+        >>> print(param.child('val').value())
+        5
+        """
+        if isinstance(settings, List):
+            _settings = Parameter.create(
+                title="Settings",
+                name="settings",
+                type="group",
+                children=settings,
+                showTop=False,
+            )
+        elif isinstance(settings, Path) or isinstance(settings, str):
+            settings = Path(settings)
+            _settings = Parameter.create(
+                title="Settings",
+                name="settings",
+                type="group",
+                showTop=False,
+                children=ioxml.XML_file_to_parameter(str(settings)),
+            )
+        elif isinstance(settings, Parameter):
+            _settings = Parameter.create(
+                title="Settings", name=settings.name(), type="group", showTop=False
+            )
+            _settings.restoreState(settings.saveState())
+        else:
+            raise TypeError(f"Cannot create Parameter object from {settings}")
+        return _settings
+
+    def parameter_tree_changed(self, param, changes):
+        """Handle changes in the parameter tree and dispatch to specific handlers.
+
+        This method is called whenever any change occurs in the parameter tree.
+        It processes the changes and calls the appropriate handler method based
+        on the type of change.
+
+        Parameters
+        ----------
+        param : Parameter
+            The parameter object that emitted the change signal
+        changes : list of tuple
+            List of changes, where each change is a tuple of
+            (parameter, change_type, data)
+
+        Notes
+        -----
+        The following change types are handled:
+        - 'childAdded': A new child parameter was added
+        - 'value': A parameter value was changed
+        - 'parent': A parameter was removed (parent changed to None)
+        - 'options': Parameter options were modified
+        - 'limits': Parameter limits were changed
+        """
+        for param, change, data in changes:
+            path = self._settings.childPath(param)
+            if change == "childAdded":
+                self.child_added(param, data)
+
+            elif change == "value":
+                self.value_changed(param)
+
+            elif change == "parent":
+                self.param_deleted(param)
+
+            elif change == "options":
+                self.options_changed(param, data)
+
+            elif change == "limits":
+                self.limits_changed(param, data)
+
+    def value_changed(self, param: Parameter):
+        """Non-mandatory method to be subclassed for actions to perform when a parameter value changes.
+
+        This method is called automatically when a parameter's value is changed using
+        the setValue() method. Override this method in subclasses to implement
+        custom behavior in response to value changes.
+
+        Parameters
+        ----------
+        param : Parameter
+            The parameter whose value has just changed
+
+        Examples
+        --------
+        >>> def value_changed(self, param):
+        ...     if param.name() == 'enable_feature':
+        ...         if param.value():
+        ...             print('Feature enabled')
+        ...             self.settings.child('status', 'ready').setValue(True)
+        ...         else:
+        ...             print('Feature disabled')
+
+        Notes
+        -----
+        For this method to be triggered, changes must be made using the Parameter.setValue()
+        method, not by direct attribute assignment.
         """
         ...
 
     def child_added(self, param: Parameter, data: Parameter):
-        """Non-mandatory method to be subclassed for actions to perform when a param has been
-        added in the attribute settings
+        """Non-mandatory method to be subclassed for actions to perform when a child parameter is added.
 
-        For this to be triggered, one of the Parameter methods: **addChild**, **addChildren**
-        or **insertChildren** should be used
+        This method is called automatically when a new child parameter is added to the
+        parameter tree. Override this method in subclasses to implement custom behavior
+        in response to parameter additions.
 
         Parameters
         ----------
-        param: Parameter
-            the parameter where child will be added
-        data: Parameter
-            the child parameter
+        param : Parameter
+            The parent parameter to which the child is being added
+        data : Parameter
+            The child parameter that was added
+
+        Examples
+        --------
+        >>> def child_added(self, param, data):
+        ...     if param.name() == 'dynamic_list':
+        ...         print(f'New item added: {data.name()}')
+        ...         self.update_item_count()
+
+        Notes
+        -----
+        For this method to be triggered, one of the following Parameter methods must be used:
+        - addChild()
+        - addChildren()
+        - insertChildren()
         """
         pass
 
     def param_deleted(self, param: Parameter):
-        """Non-mandatory method to be subclassed for actions to perform when one of the param in self.settings has been deleted
+        """Non-mandatory method to be subclassed for actions to perform when a parameter is deleted.
 
-        For this to be triggered, the Parameter method: **removeChild** should be used
+        This method is called automatically when a parameter is removed from the
+        parameter tree. Override this method in subclasses to implement custom
+        cleanup or notification behavior.
 
         Parameters
         ----------
-        param: Parameter
-            the parameter that has been deleted
+        param : Parameter
+            The parameter that has been deleted from the tree
+
+        Examples
+        --------
+        >>> def param_deleted(self, param):
+        ...     if param.name() == 'temporary_setting':
+        ...         print(f'Temporary setting {param.name()} was removed')
+        ...         self.cleanup_related_resources(param)
+
+        Notes
+        -----
+        For this method to be triggered, the Parameter.removeChild() method must be used.
         """
         pass
 
     def options_changed(self, param: Parameter, data: Dict[str, Any]):
-        """Non-mandatory method to be subclassed for actions to perform when one of the options
-        of any parameter in the settings attribute has been changed.
+        """Non-mandatory method to be subclassed for actions to perform when parameter options change.
 
-        For this to be triggered, the Parameter method: **setOpts** should be used
+        This method is called automatically when options of a parameter are modified
+        using the setOpts() method. Override this method in subclasses to respond
+        to option changes such as visibility, enabled state, or other properties.
 
         Parameters
         ----------
-        param: Parameter
-            the parameter chose option has been changed
-        data: dict
-            the key is the string of the changed option
-            the value depend on the type of option
+        param : Parameter
+            The parameter whose options have been changed
+        data : dict
+            Dictionary where keys are option names (strings) and values are the
+            new option values. Common options include 'visible', 'enabled', 'readonly', etc.
+
+        Examples
+        --------
+        >>> def options_changed(self, param, data):
+        ...     if param.name() == 'advanced_mode' and 'visible' in data:
+        ...         if data['visible']:
+        ...             print('Advanced options are now visible')
+        ...         else:
+        ...             print('Advanced options are now hidden')
+
+        Notes
+        -----
+        For this method to be triggered, the Parameter.setOpts() method must be used.
         """
         pass
 
-    def limits_changed(self, param: Parameter, data: Tuple[numbers.Number, numbers.Number]):
-        """Non-mandatory method to be subclassed for actions to perform when the limits
-        of any parameter in the *settings* attribute has been changed
+    def limits_changed(
+        self, param: Parameter, data: Tuple[numbers.Number, numbers.Number]
+    ):
+        """Non-mandatory method to be subclassed for actions to perform when parameter limits change.
 
-        For this to be triggered, the Parameter method: **setLimits** should be used
+        This method is called automatically when the limits (min/max bounds) of a
+        parameter are changed. Override this method in subclasses to respond to
+        limit changes, such as validating dependent parameters or updating the UI.
 
         Parameters
         ----------
-        param: Parameter
-            the parameter chose option has been changed
-        data: tuple of numbers
-            tuple of float or int depending on the parameter type. For peculiar Parameter, could be
-            a tuple of some other objects
+        param : Parameter
+            The parameter whose limits have been changed
+        data : tuple of numbers
+            Tuple containing (min_limit, max_limit). For numeric parameters, these
+            are typically float or int values. For specialized parameters, could be
+            other comparable objects.
 
+        Examples
+        --------
+        >>> def limits_changed(self, param, data):
+        ...     if param.name() == 'temperature':
+        ...         min_temp, max_temp = data
+        ...         print(f'Temperature range updated: {min_temp}°C to {max_temp}°C')
+        ...         self.validate_current_temperature()
+
+        Notes
+        -----
+        For this method to be triggered, the Parameter.setLimits() method must be used.
         """
-        pass      
+        pass
 
     def save_settings_slot(self, file_path: Path = None):
-        """ Method to save the current settings using a xml file extension.
+        """Save the current settings to an XML file.
 
-        The starting directory is the user config folder with a subfolder called settings folder
+        Opens a file dialog for the user to select a save location, or uses the
+        provided file path. The settings are serialized to XML format and saved
+        to disk.
 
         Parameters
         ----------
-        file_path: Path
-            Path like object pointing to a xml file encoding a Parameter object
-            If None, opens a file explorer window to save manually a file
+        file_path : Path, optional
+            Path where the settings should be saved. If None or False, opens a
+            file dialog for the user to select a location. The file extension
+            must be '.xml'. Default is None.
+
+        Notes
+        -----
+        The starting directory for the file dialog is the user's config folder
+        with a 'settings' subfolder. The file is automatically given a .xml
+        extension if not already present.
+
+        Examples
+        --------
+        >>> manager = ParameterManager()
+        >>> # Interactive save
+        >>> manager.save_settings_slot()
+        >>> # Programmatic save
+        >>> manager.save_settings_slot(Path('my_settings.xml'))
         """
         if file_path is None or file_path is False:
-            file_path = select_file(get_set_config_dir('settings', user=True), save=True, ext='xml', filter='*.xml',
-                                    force_save_extension=True)
+            file_path = select_file(
+                get_set_config_dir("settings", user=True),
+                save=True,
+                ext="xml",
+                filter="*.xml",
+                force_save_extension=True,
+            )
         else:
             file_path = Path(file_path)
-            if '.xml' != file_path.suffix:
+            if ".xml" != file_path.suffix:
                 return
         if file_path:
             ioxml.parameter_to_xml_file(self.settings, file_path.resolve())
-            logger.info(f'The settings have been successfully saved at {file_path}')
+            logger.info(f"The settings have been successfully saved at {file_path}")
 
     def _get_settings_from_file(self):
-        return select_file(get_set_config_dir('settings', user=True), save=False, ext='xml', filter='*.xml',
-                           force_save_extension=True)
+        """Open a file dialog to select an XML settings file.
+
+        Returns
+        -------
+        Path or None
+            Path to the selected XML file, or None if the dialog was cancelled
+
+        Notes
+        -----
+        The file dialog starts in the user's config folder with a 'settings' subfolder.
+        """
+        return select_file(
+            get_set_config_dir("settings", user=True),
+            save=False,
+            ext="xml",
+            filter="*.xml",
+            force_save_extension=True,
+        )
 
     def load_settings_slot(self, file_path: Path = None):
-        """ Method to load settings into the parameter using a xml file extension.
+        """Load settings from an XML file, replacing current settings entirely.
 
-        The starting directory is the user config folder with a subfolder called settings folder
+        Opens a file dialog for the user to select a file, or uses the provided
+        file path. The current parameter tree structure is completely replaced
+        with the loaded settings.
 
         Parameters
         ----------
-        file_path: Path
-            Path like object pointing to a xml file encoding a Parameter object
-            If None, opens a file explorer window to pick manually a file
+        file_path : Path, optional
+            Path to the XML file containing saved settings. If None or False,
+            opens a file dialog for the user to select a file. Default is None.
+
+        Notes
+        -----
+        The starting directory for the file dialog is the user's config folder
+        with a 'settings' subfolder. This method completely replaces the current
+        settings structure, unlike update_settings_slot() which requires matching
+        structure.
+
+        Warning
+        -------
+        This operation replaces all current settings. Any unsaved changes will be lost.
+
+        Examples
+        --------
+        >>> manager = ParameterManager()
+        >>> # Interactive load
+        >>> manager.load_settings_slot()
+        >>> # Programmatic load
+        >>> manager.load_settings_slot(Path('saved_settings.xml'))
+
+        See Also
+        --------
+        update_settings_slot : Update settings while preserving structure
+        save_settings_slot : Save current settings to file
         """
         if file_path is None or file_path is False:
             file_path = self._get_settings_from_file()
         if file_path:
             self.settings = file_path.resolve()
-            logger.info(f'The settings from {file_path} have been successfully loaded')            
+            logger.info(f"The settings from {file_path} have been successfully loaded")
 
     def update_settings_slot(self, file_path: Path = None):
-        """ Method to update settings using a xml file extension.
+        """Update settings from an XML file with matching structure validation.
 
-        The file should define the same settings structure (names and children)
-
-        The starting directory is the user config folder with a subfolder called settings folder
+        Opens a file dialog for the user to select a file, or uses the provided
+        file path. The loaded settings must have the same structure (parameter names
+        and hierarchy) as the current settings. Only the values are updated, not
+        the structure.
 
         Parameters
         ----------
-        file_path: Path
-            Path like object pointing to a xml file encoding a Parameter object
-            If None, opens a file explorer window to pick manually a file
+        file_path : Path, optional
+            Path to the XML file containing settings to apply. If None or False,
+            opens a file dialog for the user to select a file. Default is None.
+
+        Notes
+        -----
+        The starting directory for the file dialog is the user's config folder
+        with a 'settings' subfolder. The loaded settings must have identical
+        structure (same parameter names and children) as the current settings,
+        otherwise the update is rejected with a warning message.
+
+        Examples
+        --------
+        >>> manager = ParameterManager()
+        >>> # Interactive update
+        >>> manager.update_settings_slot()
+        >>> # Programmatic update
+        >>> manager.update_settings_slot(Path('compatible_settings.xml'))
+
+        See Also
+        --------
+        load_settings_slot : Load settings without structure validation
+        save_settings_slot : Save current settings to file
         """
         if file_path is None or file_path is False:
             file_path = self._get_settings_from_file()
         if file_path:
             _settings = self.create_parameter(file_path.resolve())
             # Checking if both parameters have the same structure
-            sameStruct = utils.compareStructureParameter(self.settings,_settings)
+            sameStruct = utils.compareStructureParameter(self.settings, _settings)
             if sameStruct:  # Update if true
                 self.settings = _settings
-                logger.info(f'The settings from {file_path} have been successfully applied')                            
+                logger.info(
+                    f"The settings from {file_path} have been successfully applied"
+                )
             else:
-                logger.info(f'The loaded settings from {file_path} do not match the current settings structure and cannot be applied.')
+                logger.info(
+                    f"The loaded settings from {file_path} do not match the current settings structure and cannot be applied."
+                )
 
     def _apply_filter(self, text: str):
-        """Apply filter to parameter tree with optimized updates"""
+        """Apply search filter to the parameter tree with optimized updates.
+
+        Parameters
+        ----------
+        text : str
+            The search text to filter parameters by. Empty string shows all parameters.
+
+        Notes
+        -----
+        Uses a tree change blocker to batch UI updates for better performance when
+        filtering large parameter trees.
+        """
         with self.settings.treeChangeBlocker():
             filter_parameter_tree(self.settings, text)
 
-
     def search_settings_slot(self, text: str = ""):
-        """Handle search text changes"""
+        """Handle search text changes and filter the parameter tree.
+
+        This slot is connected to the search widget's text changed signal. It stores
+        the current search text and applies the filter to show only matching parameters.
+
+        Parameters
+        ----------
+        text : str, optional
+            The search text to filter parameters by. Empty string shows all
+            parameters. Default is "".
+
+        Notes
+        -----
+        The search is typically case-insensitive and matches against parameter
+        names and titles.
+        """
         self._current_filter_text = text
         self._apply_filter(text)
 
     def on_toolbar_toggled(self):
-        """Handle toolbar expand/collapse - reapply or clear filter"""
+        """Handle toolbar expand/collapse events and manage search filter state.
+
+        When the toolbar is expanded, restores the previous search filter.
+        When collapsed, clears the search filter to show all parameters again.
+
+        Notes
+        -----
+        This ensures that collapsing the toolbar (which hides the search field)
+        also clears any active search filter, providing a consistent user experience.
+        """
         search_widget = self._settings_tree.get_action("search_settings")
 
         if search_widget:

--- a/src/pymodaq_gui/managers/parameter_manager.py
+++ b/src/pymodaq_gui/managers/parameter_manager.py
@@ -2,7 +2,10 @@ import numbers
 from pathlib import Path
 from typing import List, Union, Dict, Optional, Tuple, Any
 
-from qtpy import QtWidgets, QtCore
+from qtpy import QtWidgets, QtCore, QtGui
+from pymodaq_gui.parameter.utils import filter_parameter_tree
+from pymodaq_gui.utils.widgets.collapsible_widget import CollapsibleWidget
+from pymodaq_gui.utils.widgets.search_lineedit import SearchLineEdit
 from pymodaq_gui.managers.action_manager import ActionManager
 from pymodaq_gui.parameter import Parameter, ParameterTree, ioxml, utils
 from pymodaq_gui.utils.file_io import select_file
@@ -31,18 +34,18 @@ class ParameterTreeWidget(ActionManager):
 
         #self.tree.setMinimumWidth(150)
         #self.tree.setMinimumHeight(300)
-        
+        toggle_top = QtWidgets.QPushButton("▼")
+        self.collapsible_widget = CollapsibleWidget(
+            toggle_widget=toggle_top,
+            collapsible_widget=self.toolbar,
+            direction="top",
+            content_before_toggle=False,
+        )
+
         # Making the buttons
         self.setup_actions(action_list) 
-        # Making the splitter
-        self.splitter = QtWidgets.QSplitter(QtCore.Qt.Vertical)
-        # Adding the toolbar + the parameter tree
-        self.splitter.addWidget(toolbar)
-        self.splitter.addWidget(self.tree)
-        # Hiding toolbar
-        self.splitter.setSizes([0, 300])
-        # Adding splitter to layout
-        self.widget.layout().addWidget(self.splitter)
+        self.widget.layout().addWidget(self.collapsible_widget)
+        self.widget.layout().addWidget(self.tree)        
         self.widget.layout().setContentsMargins(0, 0, 0, 0)
 
     def setup_actions(self, action_list: tuple = ('save', 'update', 'load')):

--- a/src/pymodaq_gui/managers/parameter_manager.py
+++ b/src/pymodaq_gui/managers/parameter_manager.py
@@ -3,9 +3,7 @@ from pathlib import Path
 from typing import List, Union, Dict, Optional, Tuple, Any
 
 from qtpy import QtWidgets, QtCore, QtGui
-from pymodaq_gui.parameter.utils import filter_parameter_tree
 from pymodaq_gui.utils.widgets.collapsible_widget import CollapsibleWidget
-from pymodaq_gui.utils.widgets.search_lineedit import SearchLineEdit
 from pymodaq_gui.managers.action_manager import ActionManager
 from pymodaq_gui.parameter import Parameter, ParameterTree, ioxml, utils
 from pymodaq_gui.utils.file_io import select_file

--- a/src/pymodaq_gui/parameter/utils.py
+++ b/src/pymodaq_gui/parameter/utils.py
@@ -339,7 +339,71 @@ def set_param_from_param(param_old, param_new):
         # except Exception as e:
         #    print(str(e))
 
+def filter_parameter_tree(param:Parameter, search_text:str = "") -> bool:
+    """
+    Filter parameter tree based on search text.
+    Returns True if this parameter or any of its children match the search.
+    """
+    if not search_text:
+        # If search is empty, show everything
+        param.show()
+        for child in param.children():
+            filter_parameter_tree(child, search_text)
+        return True
 
+    search_lower = search_text.lower()
+    param_name_lower = param.title().lower()
+
+    # Check if current parameter matches
+    current_matches = search_lower in param_name_lower
+
+    # If this is a group and it matches, show all children
+    if param.hasChildren() and current_matches:
+        param.setOpts(expanded=True)        
+        param.show()
+        for child in param.children():
+            child.show()
+            # Recursively show all descendants
+            change_visibility_all_descendants(child, visible=True)
+        return True
+
+    # Check if any children match (recursively)
+    # Each child is evaluated independently
+    any_child_matches = False
+    for child in param.children():
+        child_matches = filter_parameter_tree(child, search_text)
+        any_child_matches = any_child_matches or child_matches
+
+    # Show this parameter only if it matches OR any of its children match
+    should_show = current_matches or any_child_matches
+
+    if should_show:
+        param.show()
+        # If children match, expand this parent to show them
+        if any_child_matches and param.hasChildren():
+            items = param.items
+            if items:
+                for item in items:
+                    item.setExpanded(True)
+            param.setOpts(expanded=True)        
+    else:
+        param.hide()
+
+    return should_show
+
+def change_visibility_all_descendants(param: Parameter, visible: bool = True):
+    """Recursively show all descendants of a parameter"""
+    if param.hasChildren():
+        param.setOpts(expanded=True)
+    for child in param.children():
+        if visible:
+            child.show()
+        else:
+            child.hide()
+        change_visibility_all_descendants(child, visible)
+
+
+        
 def scroll_log(scroll_val, min_val, max_val):
     """
     Convert a scroll value [0-100] to a log scale between min_val and max_val

--- a/src/pymodaq_gui/utils/widgets/collapsible_widget.py
+++ b/src/pymodaq_gui/utils/widgets/collapsible_widget.py
@@ -1,0 +1,341 @@
+from qtpy.QtWidgets import (
+    QApplication,
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QPushButton,
+    QLabel,
+    QFrame,
+    QLineEdit,
+)
+from qtpy.QtCore import Qt, QPropertyAnimation, QEasingCurve, Signal
+import sys
+
+
+class CollapsibleWidget(QWidget):
+
+    toggled_signal = Signal(bool)  # Emits True when expanded, False when collapsed
+
+    def __init__(
+        self,
+        toggle_widget,
+        collapsible_widget,
+        direction="top",
+        content_before_toggle=True,
+        animation_duration=300,
+        parent=None,
+    ):
+        """
+        Create a collapsible widget container with multiple direction support.
+
+        Args:
+            toggle_widget: Widget that is always displayed (the button/trigger)
+            collapsible_widget: Widget that will be shown/hidden when toggling
+            direction: Direction where content appears ('top', 'bottom', 'left', 'right')
+            content_before_toggle: If True, content appears before toggle widget in layout
+            animation_duration: Duration of the animation in milliseconds
+            parent: Parent widget
+        """
+        super().__init__(parent)
+        self.toggle_widget = toggle_widget
+        self.collapsible_widget = collapsible_widget
+        self.direction = direction.lower()
+        self.content_before_toggle = content_before_toggle
+        self.animation_duration = animation_duration
+        self.is_expanded = False
+
+        # Store original text if toggle_widget is a button for symbol flipping
+        self.original_text = None
+        if isinstance(self.toggle_widget, QPushButton):
+            self.original_text = self.toggle_widget.text()
+
+        self.init_ui()
+
+    def init_ui(self):
+        # Wrap collapsible widget in a container for animation
+        self.collapsible_container = QFrame()
+        self.collapsible_container.setFrameShape(QFrame.Shape.NoFrame)
+        # self.collapsible_container.setStyleSheet("background: transparent;")
+        container_layout = QVBoxLayout(self.collapsible_container)
+        container_layout.setContentsMargins(0, 0, 0, 0)
+        container_layout.addWidget(self.collapsible_widget)
+
+        # Set initial collapsed state based on direction
+        if self.direction in ["top", "bottom"]:
+            self.collapsible_container.setMaximumHeight(0)
+            self.collapsible_container.setMinimumHeight(0)
+            self.content_size = self.collapsible_container.sizeHint().height()
+            self.animated_property = b"maximumHeight"
+        else:  # left or right
+            self.collapsible_container.setMaximumWidth(0)
+            self.collapsible_container.setMinimumWidth(0)
+            self.content_size = self.collapsible_container.sizeHint().width()
+            self.animated_property = b"maximumWidth"
+
+        # Connect toggle widget click to toggle function
+        if hasattr(self.toggle_widget, "clicked"):
+            self.toggle_widget.clicked.connect(self.toggle_content)
+
+        # Create animation for smooth expand/collapse
+        self.animation = QPropertyAnimation(
+            self.collapsible_container, self.animated_property
+        )
+        self.animation.setDuration(self.animation_duration)
+        self.animation.setEasingCurve(QEasingCurve.InOutQuad)
+
+        # Arrange widgets based on direction and content_before_toggle
+        if self.direction in ["top", "bottom"]:
+            main_layout = QVBoxLayout(self)
+            main_layout.setContentsMargins(0, 0, 0, 0)
+            main_layout.setSpacing(0)
+
+            if self.content_before_toggle:
+                main_layout.addWidget(self.collapsible_container)
+                main_layout.addWidget(self.toggle_widget)
+            else:
+                main_layout.addWidget(self.toggle_widget)
+                main_layout.addWidget(self.collapsible_container)
+
+        else:  # left or right
+            main_layout = QHBoxLayout(self)
+            main_layout.setContentsMargins(0, 0, 0, 0)
+            main_layout.setSpacing(0)
+
+            if self.content_before_toggle:
+                main_layout.addWidget(self.collapsible_container)
+                main_layout.addWidget(self.toggle_widget)
+            else:
+                main_layout.addWidget(self.toggle_widget)
+                main_layout.addWidget(self.collapsible_container)
+
+    def toggle_content(self):
+        """Toggle the visibility of the collapsible widget with animation"""
+        if self.is_expanded:
+            # Collapse animation
+            self.animation.setStartValue(self.content_size)
+            self.animation.setEndValue(0)
+            self.is_expanded = False
+            self._update_toggle_symbol(False)
+        else:
+            # Expand animation
+            # Update content size in case it changed
+            if self.direction in ["top", "bottom"]:
+                self.content_size = self.collapsible_container.sizeHint().height()
+            else:
+                self.content_size = self.collapsible_container.sizeHint().width()
+
+            self.animation.setStartValue(0)
+            self.animation.setEndValue(self.content_size)
+            self.is_expanded = True
+            self._update_toggle_symbol(True)
+
+        # Start the animation
+        self.animation.start()
+        
+        self.toggled_signal.emit(self.is_expanded)
+
+    def _update_toggle_symbol(self, expanded):
+        """Update the toggle button symbol based on expanded state"""
+        if not isinstance(self.toggle_widget, QPushButton) or not self.original_text:
+            return
+
+        text = self.original_text
+
+        # Symbol mappings for flipping
+        symbol_map = {
+            "▲": "▼",
+            "▼": "▲",
+            "◀": "▶",
+            "▶": "◀",
+            "◄": "►",
+            "►": "◄",
+            "←": "→",
+            "→": "←",
+            "↑": "↓",
+            "↓": "↑",
+            "⬆": "⬇",
+            "⬇": "⬆",
+            "⬅": "➡",
+            "➡": "⬅",
+        }
+
+        # Create reverse mapping
+        reverse_map = {v: k for k, v in symbol_map.items()}
+        symbol_map.update(reverse_map)
+
+        # Replace symbols in the text
+        new_text = text
+        for original, flipped in symbol_map.items():
+            if expanded:
+                new_text = new_text.replace(original, flipped)
+            else:
+                # When collapsing, we want to go back to original
+                # So we need to check if current text has the flipped symbol
+                current_text = self.toggle_widget.text()
+                if flipped in current_text:
+                    new_text = current_text.replace(flipped, original)
+
+        self.toggle_widget.setText(new_text)
+
+    def set_expanded(self, expanded):
+        """Programmatically set the expanded state without animation"""
+        if expanded and not self.is_expanded:
+            if self.direction in ["top", "bottom"]:
+                self.content_size = self.collapsible_container.sizeHint().height()
+                self.collapsible_container.setMaximumHeight(self.content_size)
+            else:
+                self.content_size = self.collapsible_container.sizeHint().width()
+                self.collapsible_container.setMaximumWidth(self.content_size)
+            self.is_expanded = True
+        elif not expanded and self.is_expanded:
+            if self.direction in ["top", "bottom"]:
+                self.collapsible_container.setMaximumHeight(0)
+            else:
+                self.collapsible_container.setMaximumWidth(0)
+            self.is_expanded = False
+
+
+# Demo application
+if __name__ == "__main__":
+    app = QApplication(sys.argv)
+
+    window = QWidget()
+    window.setWindowTitle("Collapsible Widget - All Directions Demo")
+    window.setGeometry(100, 100, 800, 600)
+
+    main_layout = QVBoxLayout(window)
+    main_layout.addWidget(QLabel("<h3>Collapsible Widget - All Directions</h3>"))
+
+    # Create a horizontal layout for left/right examples
+    h_layout = QHBoxLayout()
+
+    # LEFT direction example
+    left_section = QWidget()
+    left_layout = QVBoxLayout(left_section)
+    left_layout.addWidget(QLabel("<b>LEFT Direction</b>"))
+
+    toggle_left = QPushButton("◀")
+    toggle_left.setFixedWidth(30)
+    toggle_left.setStyleSheet("""
+        QPushButton {
+            background-color: #17a2b8;
+            color: white;
+            border: none;
+            font-size: 16px;
+        }
+        QPushButton:hover {
+            background-color: #138496;
+        }
+    """)
+
+    content_left = QFrame()
+    content_left.setStyleSheet("background-color: #d1ecf1; border: 2px solid #17a2b8;")
+    content_left_layout = QVBoxLayout(content_left)
+    content_left_layout.addWidget(QLabel("Left Panel"))
+    content_left_layout.addWidget(QPushButton("Option 1"))
+    content_left_layout.addWidget(QPushButton("Option 2"))
+
+    collapsible_left = CollapsibleWidget(
+        toggle_left, content_left, direction="left", content_before_toggle=True
+    )
+    left_layout.addWidget(collapsible_left)
+    left_layout.addStretch()
+
+    h_layout.addWidget(left_section)
+
+    # RIGHT direction example
+    right_section = QWidget()
+    right_layout = QVBoxLayout(right_section)
+    right_layout.addWidget(QLabel("<b>RIGHT Direction</b>"))
+
+    toggle_right = QPushButton("▶")
+    toggle_right.setFixedWidth(30)
+    toggle_right.setStyleSheet("""
+        QPushButton {
+            background-color: #28a745;
+            color: white;
+            border: none;
+            font-size: 16px;
+        }
+        QPushButton:hover {
+            background-color: #218838;
+        }
+    """)
+
+    content_right = QFrame()
+    content_right.setStyleSheet("background-color: #d4edda; border: 2px solid #28a745;")
+    content_right_layout = QVBoxLayout(content_right)
+    content_right_layout.addWidget(QLabel("Right Panel"))
+    content_right_layout.addWidget(QLineEdit("Setting 1"))
+    content_right_layout.addWidget(QLineEdit("Setting 2"))
+
+    collapsible_right = CollapsibleWidget(
+        toggle_right, content_right, direction="right", content_before_toggle=False
+    )
+    right_layout.addWidget(collapsible_right)
+    right_layout.addStretch()
+
+    h_layout.addWidget(right_section)
+
+    main_layout.addLayout(h_layout)
+
+    # TOP direction example
+    main_layout.addWidget(QLabel("<b>TOP Direction</b>"))
+
+    toggle_top = QPushButton("▲ Expand Top")
+    toggle_top.setStyleSheet("""
+        QPushButton {
+            background-color: #007bff;
+            color: white;
+            border: none;
+            padding: 8px;
+        }
+        QPushButton:hover {
+            background-color: #0056b3;
+        }
+    """)
+
+    content_top = QFrame()
+    content_top.setStyleSheet("background-color: #cce5ff; border: 2px solid #007bff;")
+    content_top_layout = QVBoxLayout(content_top)
+    content_top_layout.addWidget(QLabel("Top Content Area"))
+    content_top_layout.addWidget(QPushButton("Action Button"))
+
+    collapsible_top = CollapsibleWidget(
+        toggle_top, content_top, direction="top", content_before_toggle=True
+    )
+    main_layout.addWidget(collapsible_top)
+
+    # BOTTOM direction example
+    main_layout.addWidget(QLabel("<b>BOTTOM Direction</b>"))
+
+    toggle_bottom = QPushButton("▼ Expand Bottom")
+    toggle_bottom.setStyleSheet("""
+        QPushButton {
+            background-color: #ffc107;
+            color: black;
+            border: none;
+            padding: 8px;
+        }
+        QPushButton:hover {
+            background-color: #e0a800;
+        }
+    """)
+
+    content_bottom = QFrame()
+    content_bottom.setStyleSheet(
+        "background-color: #fff3cd; border: 2px solid #ffc107;"
+    )
+    content_bottom_layout = QVBoxLayout(content_bottom)
+    content_bottom_layout.addWidget(QLabel("Bottom Content Area"))
+    content_bottom_layout.addWidget(QLabel("Additional Information"))
+
+    collapsible_bottom = CollapsibleWidget(
+        toggle_bottom, content_bottom, direction="bottom", content_before_toggle=False
+    )
+    main_layout.addWidget(collapsible_bottom)
+
+    main_layout.addStretch()
+
+    window.show()
+    sys.exit(app.exec_())

--- a/src/pymodaq_gui/utils/widgets/collapsible_widget.py
+++ b/src/pymodaq_gui/utils/widgets/collapsible_widget.py
@@ -261,7 +261,7 @@ if __name__ == "__main__":
     # TOP direction example
     main_layout.addWidget(QLabel("<b>TOP Direction</b>"))
 
-    toggle_top = QPushButton("▲ Expand Top")
+    toggle_top = QPushButton("▲")
     toggle_top.setStyleSheet("""
         QPushButton {
             background-color: #007bff;
@@ -288,7 +288,7 @@ if __name__ == "__main__":
     # BOTTOM direction example
     main_layout.addWidget(QLabel("<b>BOTTOM Direction</b>"))
 
-    toggle_bottom = QPushButton("▼ Expand Bottom")
+    toggle_bottom = QPushButton("▼")
     toggle_bottom.setStyleSheet("""
         QPushButton {
             background-color: #ffc107;

--- a/src/pymodaq_gui/utils/widgets/collapsible_widget.py
+++ b/src/pymodaq_gui/utils/widgets/collapsible_widget.py
@@ -11,6 +11,19 @@ from qtpy.QtWidgets import (
 from qtpy.QtCore import Qt, QPropertyAnimation, QEasingCurve, Signal
 import sys
 
+symbol_pairs = [
+    ("▲", "▼"),
+    ("◀", "▶"),
+    ("◄", "►"),
+    ("↑", "↓"),
+    ("→", "←"),
+    ("⬆", "⬇"),
+    ("⬅", "➡"),
+]
+symbol_map = {}
+for sym1, sym2 in symbol_pairs:
+    symbol_map[sym1] = sym2
+    symbol_map[sym2] = sym1
 
 class CollapsibleWidget(QWidget):
 
@@ -139,43 +152,13 @@ class CollapsibleWidget(QWidget):
         if not isinstance(self.toggle_widget, QPushButton) or not self.original_text:
             return
 
-        text = self.original_text
-
-        # Symbol mappings for flipping
-        symbol_map = {
-            "▲": "▼",
-            "▼": "▲",
-            "◀": "▶",
-            "▶": "◀",
-            "◄": "►",
-            "►": "◄",
-            "←": "→",
-            "→": "←",
-            "↑": "↓",
-            "↓": "↑",
-            "⬆": "⬇",
-            "⬇": "⬆",
-            "⬅": "➡",
-            "➡": "⬅",
-        }
-
-        # Create reverse mapping
-        reverse_map = {v: k for k, v in symbol_map.items()}
-        symbol_map.update(reverse_map)
-
-        # Replace symbols in the text
-        new_text = text
-        for original, flipped in symbol_map.items():
-            if expanded:
-                new_text = new_text.replace(original, flipped)
-            else:
-                # When collapsing, we want to go back to original
-                # So we need to check if current text has the flipped symbol
-                current_text = self.toggle_widget.text()
-                if flipped in current_text:
-                    new_text = current_text.replace(flipped, original)
-
-        self.toggle_widget.setText(new_text)
+        text = self.original_text if not expanded else self.toggle_widget.text()
+        
+        for symbol, flipped in symbol_map.items():
+            if symbol in text:
+                new_text = text.replace(symbol, flipped)
+                self.toggle_widget.setText(new_text)
+                break
 
     def set_expanded(self, expanded):
         """Programmatically set the expanded state without animation"""

--- a/src/pymodaq_gui/utils/widgets/collapsible_widget.py
+++ b/src/pymodaq_gui/utils/widgets/collapsible_widget.py
@@ -63,6 +63,10 @@ class CollapsibleWidget(QWidget):
             self.original_text = self.toggle_widget.text()
 
         self.init_ui()
+        self.connect_signals()
+
+    def connect_signals(self):
+        self.toggled_signal.connect(self._update_toggle_symbol)
 
     def init_ui(self):
         # Wrap collapsible widget in a container for animation
@@ -128,7 +132,6 @@ class CollapsibleWidget(QWidget):
             self.animation.setStartValue(self.content_size)
             self.animation.setEndValue(0)
             self.is_expanded = False
-            self._update_toggle_symbol(False)
         else:
             # Expand animation
             # Update content size in case it changed
@@ -140,7 +143,6 @@ class CollapsibleWidget(QWidget):
             self.animation.setStartValue(0)
             self.animation.setEndValue(self.content_size)
             self.is_expanded = True
-            self._update_toggle_symbol(True)
 
         # Start the animation
         self.animation.start()

--- a/src/pymodaq_gui/utils/widgets/collapsible_widget.py
+++ b/src/pymodaq_gui/utils/widgets/collapsible_widget.py
@@ -151,15 +151,9 @@ class CollapsibleWidget(QWidget):
         """Update the toggle button symbol based on expanded state"""
         if not isinstance(self.toggle_widget, QPushButton) or not self.original_text:
             return
-
-        text = self.original_text if not expanded else self.toggle_widget.text()
+        text = self.original_text if not expanded else symbol_map[self.original_text]        
+        self.toggle_widget.setText(text)
         
-        for symbol, flipped in symbol_map.items():
-            if symbol in text:
-                new_text = text.replace(symbol, flipped)
-                self.toggle_widget.setText(new_text)
-                break
-
     def set_expanded(self, expanded):
         """Programmatically set the expanded state without animation"""
         if expanded and not self.is_expanded:

--- a/src/pymodaq_gui/utils/widgets/search_lineedit.py
+++ b/src/pymodaq_gui/utils/widgets/search_lineedit.py
@@ -1,0 +1,135 @@
+from qtpy.QtWidgets import QApplication, QLineEdit, QWidget, QVBoxLayout
+from qtpy.QtCore import Qt, QSize, QTimer, Signal
+from qtpy.QtGui import QIcon, QPixmap, QPainter, QColor
+import sys
+
+
+class SearchLineEdit(QLineEdit):
+    # New signal that fires only after debounce delay
+    searchTextChanged = Signal(str)
+
+    def __init__(self, parent=None, debounce_ms=300):
+        super().__init__(parent)
+
+        # Debounce timer
+        self.debounce_ms = debounce_ms
+        self.search_timer = QTimer()
+        self.search_timer.setSingleShot(True)
+        self.search_timer.timeout.connect(self._emit_debounced_search)
+
+        # Connect to the native textChanged signal
+        self.textChanged.connect(self._on_text_changed)
+
+        # Set placeholder text
+        self.setPlaceholderText("Search...")
+
+        # Create a simple search icon
+        self.search_icon = self.create_search_icon()
+
+        # Style the QLineEdit
+        self.setStyleSheet("""
+            QLineEdit {
+                padding-left: 30px;
+                padding-right: 10px;
+                border: 1px solid #ccc;
+                border-radius: 15px;
+                background-color: #f5f5f5;
+                min-height: 30px;
+                font-size: 13px;
+                color: #333;                           
+            }
+            QLineEdit:focus {
+                border: 1px solid #4a90e2;
+                background-color: white;
+                color: #000;                           
+            }
+        """)
+
+        # Set fixed width for small widget
+        self.setFixedWidth(200)
+
+    def _on_text_changed(self, text):
+        """Called on every keystroke"""
+        # Stop any pending search
+        self.search_timer.stop()
+
+        # If search is cleared, emit immediately for better UX
+        if not text.strip():
+            self.searchTextChanged.emit(text)
+        else:
+            # Otherwise, start debounce timer
+            self.search_timer.start(self.debounce_ms)
+
+    def _emit_debounced_search(self):
+        """Emit the debounced signal"""
+        self.searchTextChanged.emit(self.text())
+
+    def create_search_icon(self):
+        """Create a simple magnifying glass icon"""
+        pixmap = QPixmap(16, 16)
+        pixmap.fill(Qt.GlobalColor.transparent)
+
+        painter = QPainter(pixmap)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+
+        # Draw magnifying glass
+        pen = painter.pen()
+        pen.setColor(QColor("#888"))
+        pen.setWidth(2)
+        painter.setPen(pen)
+
+        # Circle
+        painter.drawEllipse(2, 2, 9, 9)
+        # Handle
+        painter.drawLine(10, 10, 14, 14)
+
+        painter.end()
+        return QIcon(pixmap)
+
+    def paintEvent(self, event):
+        super().paintEvent(event)
+
+        # Draw the search icon
+        painter = QPainter(self)
+        icon_size = QSize(16, 16)
+        icon_rect = self.search_icon.pixmap(icon_size).rect()
+        icon_rect.moveCenter(self.rect().center())
+        icon_rect.moveLeft(8)
+
+        self.search_icon.paint(painter, icon_rect)
+
+
+# Demo application
+class DemoWindow(QWidget):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("Search Widget Demo")
+        self.setGeometry(100, 100, 300, 150)
+
+        layout = QVBoxLayout()
+        layout.setContentsMargins(20, 20, 20, 20)
+
+        # Create search widget
+        self.search = SearchLineEdit(debounce_ms=300)
+
+        # Connect to DEBOUNCED signal (not textChanged)
+        self.search.searchTextChanged.connect(self.on_search_changed)
+
+        # You can still access immediate changes if needed:
+        # self.search.textChanged.connect(self.on_immediate_change)
+
+        layout.addWidget(self.search)
+        layout.addStretch()
+
+        self.setLayout(layout)
+
+    def on_search_changed(self, text):
+        print(f"Debounced search: '{text}'")
+        # This is where you'd call filter_parameter_tree()
+
+
+if __name__ == "__main__":
+    app = QApplication(sys.argv)
+    window = DemoWindow()
+    window.show()
+    sys.exit(app.exec())

--- a/tests/parameter_test/parameter_manager_search_test.py
+++ b/tests/parameter_test/parameter_manager_search_test.py
@@ -1,0 +1,183 @@
+"""
+Tests for ParameterManager search functionality
+"""
+import pytest
+from qtpy import QtWidgets, QtCore
+from pymodaq_gui.parameter import Parameter
+from pymodaq_gui.managers.parameter_manager import ParameterManager, ParameterTreeWidget
+
+
+@pytest.fixture
+def sample_params():
+    """Sample parameter structure for testing"""
+    return [
+        {
+            'title': 'Main Settings',
+            'name': 'main_settings',
+            'type': 'group',
+            'children': [
+                {'title': 'Detector Mode', 'name': 'detector_mode', 'type': 'list',
+                 'limits': ['Single', 'Continuous'], 'value': 'Single'},
+                {'title': 'Integration Time', 'name': 'integration_time', 
+                 'type': 'float', 'value': 100.0},
+            ]
+        },
+        {
+            'title': 'Advanced Settings',
+            'name': 'advanced_settings',
+            'type': 'group',
+            'children': [
+                {'title': 'Temperature Control', 'name': 'temp_control', 'type': 'bool'},
+                {
+                    'title': 'Calibration',
+                    'name': 'calibration',
+                    'type': 'group',
+                    'children': [
+                        {'title': 'Offset', 'name': 'offset', 'type': 'float', 'value': 0.0},
+                    ]
+                }
+            ]
+        }
+    ]
+
+
+@pytest.fixture
+def param_manager(qtbot, sample_params):
+    """Fixture providing a fresh ParameterManager instance for each test"""
+    manager = ParameterManager(settings_name='test_settings', 
+                               action_list=('search', 'save', 'load'))
+    # Create fresh parameter tree for each test
+    manager.settings = Parameter.create(name='test_settings', type='group', 
+                                       children=sample_params, showTop=False)
+    qtbot.addWidget(manager.settings_tree)
+    
+    yield manager
+    
+    # Cleanup after each test
+    manager.settings_tree.close()
+    manager.settings_tree.deleteLater()
+
+
+class TestSearchBasics:
+    """Core search functionality tests"""
+    
+    def test_search_widget_exists(self, param_manager:ParameterManager):
+        """Test that search widget is created when 'search' in action_list"""
+        search_widget = param_manager._settings_tree.get_action('search_settings')
+        assert search_widget is not None
+        assert isinstance(search_widget, QtWidgets.QLineEdit)
+    
+    def test_empty_search_shows_all(self, param_manager:ParameterManager):
+        """Test that empty search shows all parameters"""
+        param_manager.search_settings_slot("")
+        
+        for item in param_manager.tree.listAllItems():
+            assert not item.isHidden()
+    
+    def test_search_filters_parameters(self, param_manager:ParameterManager):
+        """Test that search hides non-matching parameters"""
+        param_manager.search_settings_slot("detector")
+        
+        # Check that some items are hidden
+        all_items = param_manager.tree.listAllItems()
+        hidden_items = [item for item in all_items if item.isHidden()]
+        assert len(hidden_items) > 0
+    
+    def test_search_case_insensitive(self, param_manager:ParameterManager):
+        """Test that search is case-insensitive"""
+        param_manager.search_settings_slot("DETECTOR")
+        
+        detector_items = [item for item in param_manager.tree.listAllItems() 
+                         if 'detector' in item.param.title().lower()]
+        
+        for item in detector_items:
+            assert not item.isHidden()
+    
+    def test_search_expands_parent_groups(self, param_manager:ParameterManager):
+        """Test that parent groups expand when children match"""
+        param_manager.search_settings_slot("offset")
+        
+        # Find calibration parameter and check its expanded state
+        calibration = param_manager.settings.child('advanced_settings', 'calibration')
+        assert calibration is not None
+        
+        # Check if the parameter opts show it should be expanded
+        assert calibration.opts.get('expanded', False) == True
+
+
+class TestKeyboardShortcuts:
+    """Keyboard shortcut tests"""
+    
+    def test_ctrl_f_activates_search(self, qtbot, param_manager:ParameterManager):
+        """Test that Ctrl+F expands toolbar and focuses search"""
+        assert not param_manager._settings_tree.collapsible_widget.is_expanded
+        
+        # Show the widget and process events
+        param_manager.settings_tree.show()
+        qtbot.waitForWindowShown(param_manager.settings_tree)
+        qtbot.wait(100)
+        
+        # Trigger the shortcut directly
+        param_manager._settings_tree.search_activate_shortcut.activated.emit()
+        qtbot.wait(200)  # Give more time for animation and focus
+        
+        assert param_manager._settings_tree.collapsible_widget.is_expanded
+        
+        # Check that activate_search was called by verifying widget state
+        search_widget = param_manager._settings_tree.get_action('search_settings')
+        assert search_widget is not None
+        # Just verify the toolbar is expanded, focus is unreliable in tests
+    
+    def test_escape_collapses_toolbar(self, qtbot, param_manager:ParameterManager):
+        """Test that Escape key collapses toolbar"""
+        param_manager.settings_tree.show()
+        qtbot.waitForWindowShown(param_manager.settings_tree)
+        
+        param_manager._settings_tree.activate_search()
+        qtbot.wait(200)
+        assert param_manager._settings_tree.collapsible_widget.is_expanded
+        
+        # Trigger the shortcut directly
+        param_manager._settings_tree.search_escape_shortcut.activated.emit()
+        qtbot.wait(200)
+        
+        assert not param_manager._settings_tree.collapsible_widget.is_expanded
+
+
+class TestSearchIntegration:
+    """Integration tests"""
+    
+    def test_toolbar_toggle_clears_filter(self, param_manager:ParameterManager):
+        """Test that collapsing toolbar clears the filter"""
+        param_manager.search_settings_slot("detector")
+        assert param_manager._current_filter_text == "detector"
+        
+        param_manager._settings_tree.collapsible_widget.is_expanded = False
+        param_manager.on_toolbar_toggled()
+        
+        assert param_manager._current_filter_text == ""
+    
+    def test_clear_search_restores_all(self, qtbot, param_manager:ParameterManager):
+        """Test that clearing search restores all parameters"""
+        search_widget = param_manager._settings_tree.get_action('search_settings')
+        
+        qtbot.keyClicks(search_widget, "detector")
+        qtbot.wait(350)
+        
+        search_widget.clear()
+        qtbot.wait(350)
+        
+        for item in param_manager.tree.listAllItems():
+            assert not item.isHidden()
+    
+    def test_initialization_without_search(self, qtbot):
+        """Test that manager works without search in action_list"""
+        manager = ParameterManager(settings_name='test', 
+                                  action_list=('save', 'load'))
+        qtbot.addWidget(manager.settings_tree)
+        
+        assert not manager._settings_tree.get_action('search_settings').isVisible()
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])

--- a/tests/utils/widgets/collapsible_widget_test.py
+++ b/tests/utils/widgets/collapsible_widget_test.py
@@ -1,0 +1,115 @@
+import pytest
+from qtpy.QtWidgets import QPushButton, QLabel, QFrame, QVBoxLayout
+from qtpy.QtCore import Qt
+from pymodaq_gui.utils.widgets.collapsible_widget import CollapsibleWidget
+
+
+@pytest.fixture
+def toggle_button():
+    return QPushButton("▼ Toggle")
+
+
+@pytest.fixture
+def content_widget():
+    widget = QFrame()
+    layout = QVBoxLayout(widget)
+    layout.addWidget(QLabel("Test Content"))
+    return widget
+
+
+class TestCollapsibleWidget:
+    """Core functionality tests"""
+
+    def test_starts_collapsed(self, qtbot, toggle_button, content_widget):
+        """Widget should start in collapsed state"""
+        widget = CollapsibleWidget(toggle_button, content_widget)
+        qtbot.addWidget(widget)
+        
+        assert widget.is_expanded is False
+
+    def test_toggle_expands_and_collapses(self, qtbot, toggle_button, content_widget):
+        """Toggle should expand then collapse"""
+        widget = CollapsibleWidget(toggle_button, content_widget)
+        qtbot.addWidget(widget)
+        
+        widget.toggle_content()
+        assert widget.is_expanded is True
+        
+        widget.toggle_content()
+        assert widget.is_expanded is False
+
+    def test_button_click_triggers_toggle(self, qtbot, toggle_button, content_widget):
+        """Clicking button should expand widget"""
+        widget = CollapsibleWidget(toggle_button, content_widget)
+        qtbot.addWidget(widget)
+        
+        with qtbot.waitSignal(widget.toggled_signal, timeout=1000):
+            qtbot.mouseClick(toggle_button, Qt.MouseButton.LeftButton)
+        
+        assert widget.is_expanded is True
+
+    def test_toggled_signal_emits_correct_state(self, qtbot, toggle_button, content_widget):
+        """Signal should emit True when expanded, False when collapsed"""
+        widget = CollapsibleWidget(toggle_button, content_widget)
+        qtbot.addWidget(widget)
+        
+        with qtbot.waitSignal(widget.toggled_signal) as blocker:
+            widget.toggle_content()
+        assert blocker.args[0] is True
+        
+        with qtbot.waitSignal(widget.toggled_signal) as blocker:
+            widget.toggle_content()
+        assert blocker.args[0] is False
+
+    def test_vertical_direction_animates_height(self, qtbot, toggle_button, content_widget):
+        """Vertical directions should animate maximumHeight"""
+        widget = CollapsibleWidget(toggle_button, content_widget, direction="bottom")
+        qtbot.addWidget(widget)
+        
+        assert widget.animated_property == b"maximumHeight"
+
+    def test_horizontal_direction_animates_width(self, qtbot, toggle_button, content_widget):
+        """Horizontal directions should animate maximumWidth"""
+        widget = CollapsibleWidget(toggle_button, content_widget, direction="left")
+        qtbot.addWidget(widget)
+        
+        assert widget.animated_property == b"maximumWidth"
+
+    @pytest.mark.parametrize("original,expected", [
+            ("▲", "▼"),
+            ("▼", "▲"),
+            ("◀", "▶"),
+            ("▶", "◀"),
+            ("◄", "►"),
+            ("►", "◄"),
+            ("←", "→"),
+            ("→", "←"),
+            ("↑", "↓"),
+            ("↓", "↑"),
+            ("⬆", "⬇"),
+            ("⬇", "⬆"),
+            ("⬅", "➡"),
+            ("➡", "⬅"),
+    ])
+    def test_symbol_flipping(self, qtbot, content_widget, original, expected):
+        """Symbols should flip when expanding"""
+        button = QPushButton(original)
+        widget = CollapsibleWidget(button, content_widget)
+        qtbot.addWidget(widget)
+        
+        widget.toggle_content()
+        button_text = button.text()
+        assert expected in button_text
+
+    def test_set_expanded_programmatically(self, qtbot, toggle_button, content_widget):
+        """set_expanded should change state without animation"""
+        widget = CollapsibleWidget(toggle_button, content_widget, direction="bottom")
+        qtbot.addWidget(widget)
+        
+        widget.set_expanded(True)
+        assert widget.is_expanded is True
+        assert widget.collapsible_container.maximumHeight() > 0
+        
+        widget.set_expanded(False)
+        assert widget.is_expanded is False
+        assert widget.collapsible_container.maximumHeight() == 0

--- a/tests/utils/widgets/collapsible_widget_test.py
+++ b/tests/utils/widgets/collapsible_widget_test.py
@@ -6,7 +6,7 @@ from pymodaq_gui.utils.widgets.collapsible_widget import CollapsibleWidget
 
 @pytest.fixture
 def toggle_button():
-    return QPushButton("▼ Toggle")
+    return QPushButton("▼")
 
 
 @pytest.fixture

--- a/tests/utils/widgets/search_lineedit_test.py
+++ b/tests/utils/widgets/search_lineedit_test.py
@@ -1,0 +1,96 @@
+import pytest
+from qtpy.QtCore import Qt
+from pymodaq_gui.utils.widgets.search_lineedit import SearchLineEdit
+
+
+@pytest.fixture
+def search_widget(qtbot):
+    widget = SearchLineEdit(debounce_ms=100)  # Shorter for faster tests
+    qtbot.addWidget(widget)
+    return widget
+
+
+class TestSearchLineEdit:
+    """Core functionality tests"""
+
+    def test_empty_text_emits_immediately(self, qtbot, search_widget):
+        """Clearing search should emit immediately without debounce"""
+        search_widget.setText("test")
+        
+        with qtbot.waitSignal(search_widget.searchTextChanged, timeout=200) as blocker:
+            search_widget.clear()
+        
+        assert blocker.args[0] == ""
+
+    def test_text_emits_after_debounce(self, qtbot, search_widget):
+        """Non-empty text should emit after debounce delay"""
+        with qtbot.waitSignal(search_widget.searchTextChanged, timeout=500) as blocker:
+            search_widget.setText("test")
+        
+        assert blocker.args[0] == "test"
+
+    def test_rapid_changes_emit_once(self, qtbot, search_widget):
+        """Rapid typing should result in single debounced signal"""
+        signal_count = []
+        search_widget.searchTextChanged.connect(lambda t: signal_count.append(t))
+        
+        search_widget.setText("t")
+        search_widget.setText("te")
+        search_widget.setText("tes")
+        search_widget.setText("test")
+        
+        qtbot.wait(200)
+        
+        assert len(signal_count) == 1
+        assert signal_count[0] == "test"
+
+    def test_debounce_resets_on_new_input(self, qtbot, search_widget):
+        """New input should reset debounce timer"""
+        search_widget.setText("te")
+        qtbot.wait(50)  # Less than debounce time
+        search_widget.setText("test")  # Should reset timer
+        
+        with qtbot.waitSignal(search_widget.searchTextChanged, timeout=500) as blocker:
+            pass
+        
+        assert blocker.args[0] == "test"
+
+    def test_signal_not_emitted_before_debounce(self, qtbot, search_widget):
+        """Signal should not emit before debounce time elapses"""
+        signal_fired = []
+        search_widget.searchTextChanged.connect(lambda t: signal_fired.append(t))
+        
+        search_widget.setText("test")
+        qtbot.wait(50)  # Less than 100ms debounce
+        
+        assert len(signal_fired) == 0
+
+    def test_custom_debounce_time(self, qtbot):
+        """Custom debounce time should be respected"""
+        widget = SearchLineEdit(debounce_ms=500)
+        qtbot.addWidget(widget)
+        
+        assert widget.debounce_ms == 500
+
+    def test_search_icon_created(self, search_widget):
+        """Search icon should be created and not null"""
+        assert search_widget.search_icon is not None
+        assert not search_widget.search_icon.isNull()
+
+    def test_whitespace_only_emits_immediately(self, qtbot, search_widget):
+        """Whitespace-only text should emit immediately like empty text"""
+        with qtbot.waitSignal(search_widget.searchTextChanged, timeout=200) as blocker:
+            search_widget.setText("   ")
+        
+        assert blocker.args[0] == "   "
+
+    def test_timer_stops_when_cleared(self, qtbot, search_widget):
+        """Timer should stop when text is cleared"""
+        search_widget.setText("test")
+        assert search_widget.search_timer.isActive()
+        
+        search_widget.clear()
+        qtbot.wait(50)
+        
+        # After clearing, timer should not be active (or restarted for immediate emit)
+        assert search_widget.text() == ""


### PR DESCRIPTION
**Context:** Finding relevant elements in a parametertree can be cumbersome as the number of elements grow with potential many groups/subgroups. This PR adresses this issue by proposing a search mechanism implemented in the ParameterManager.

In practice, this PR follows #99 and adds: 
-  a new QlineEdit widget dedicated to search with a custom time-delayed control before triggering the filter (200 ms default)
- The QLineEdit is added to the collapsible widget of the parameter manager when the keyword "search" is given (similar as "save"/"load"/"update")

The text typed in the Qline edit will only show the parameter items whose titles contain the typed text.
Overall, it allows to easily find elements in a ParameterTree. The filtering only applies when the collapsible widget is expanded.

In addition, two shortcuts have been added:
- ctrl+f opens up/closes the collapsible widget and gives/clear focus to/from the QLineEdit. 
- esc closes the collapsible widget

Here is a demo:
https://github.com/user-attachments/assets/8aede415-5439-4ac8-8b42-ae6b9c2d764b

