### PR TITLE
Bugfix/ParameterManager_was_losing_name_attribute_when_filtering

### DIFF
--- a/src/pymodaq_gui/managers/parameter_manager.py
+++ b/src/pymodaq_gui/managers/parameter_manager.py
@@ -716,7 +716,10 @@ class ParameterManager:
         filtering large parameter trees.
         """
         with self.settings.treeChangeBlocker():
-            filter_parameter_tree(self.settings, text)
+            # Filter each child independently to avoid calling show() on the root parameter
+            # This prevents issues with the root parameter name when showTop=False
+            for child in self.settings.children():
+                filter_parameter_tree(child, text)                            
 
     def search_settings_slot(self, text: str = ""):
         """Handle search text changes and filter the parameter tree.


### PR DESCRIPTION
The implementation on the filtering was working directly on self.settings.

However, using the `show` method on the root element leads to some weird behavior resulting in losing the name of the settings.

This then leads to some issues for the saving/loading/updating as the xml format is not adapted to empty empty first element.

This PR now only apply filter on self.settings.children() to avoid it.