### PR TITLE
Adding comparison of parent in compareStructure/compareValues

### DIFF
--- a/src/pymodaq_gui/parameter/utils.py
+++ b/src/pymodaq_gui/parameter/utils.py
@@ -147,21 +147,24 @@ def getValues(param:Parameter,) -> OrderedDict:
     return param.getValues()
 
 
-def compareParameters(param1:Parameter, param2:Parameter, opts: list = None)-> bool:
+def compareParameters(param1:Parameter, param2:Parameter, with_self: bool = True)-> bool:
     """Compare the structure and the opts of two parameters with their children,
-     return True if structure and all opts are identical
+     return True if structure and all opts are identical.
+     If with_self is False, only the children opts are compared.
         Parameters
         ----------
         param1: Parameter
         param2: Parameter   
+        with_self: bool
         
         Returns
         -------
         Bool    
     """
-    if opts is None:
-        opts = []
-    return getOpts(param1) == getOpts(param2)
+    is_same = getOpts(param1) == getOpts(param2)
+    if with_self:        
+        is_same and (param1.opts == param2.opts)        
+    return is_same
 
     
 def compareStructureParameter(param1:Parameter, param2: Parameter,)-> bool:
@@ -178,18 +181,23 @@ def compareStructureParameter(param1:Parameter, param2: Parameter,)-> bool:
     return getStruct(param1) == getStruct(param2)
 
 
-def compareValuesParameter(param1:Parameter, param2: Parameter,)-> bool:
+def compareValuesParameter(param1:Parameter, param2: Parameter, with_self: bool = True)-> bool:
     """Compare the structure and the values of two parameters with their children, return True if structures and values are identical
         Parameters
+        If with_self is False, only the children opts are compared.
         ----------
         param1: Parameter
         param2: Parameter   
+        with_self: bool
         
         Returns
         -------
         Bool    
     """    
-    return getValues(param1) == getValues(param2)    
+    is_same = getValues(param1) == getValues(param2)
+    if with_self:        
+        is_same and (param1.value == param2.value)        
+    return is_same
 
 
 def iter_children(param, childlist: list = [], filter_type=(), filter_name=(), select_filter=False)-> list:

--- a/src/pymodaq_gui/parameter/utils.py
+++ b/src/pymodaq_gui/parameter/utils.py
@@ -163,9 +163,8 @@ def compareParameters(param1:Parameter, param2:Parameter, with_self: bool = True
     """
     is_same = getOpts(param1) == getOpts(param2)
     if with_self:        
-        is_same and (param1.opts == param2.opts)        
+        is_same = is_same and (param1.opts == param2.opts)        
     return is_same
-
     
 def compareStructureParameter(param1:Parameter, param2: Parameter,)-> bool:
     """Compare the structure of two parameters with their children, return True if structure is identical
@@ -196,7 +195,7 @@ def compareValuesParameter(param1:Parameter, param2: Parameter, with_self: bool 
     """    
     is_same = getValues(param1) == getValues(param2)
     if with_self:        
-        is_same and (param1.value == param2.value)        
+        is_same = is_same and (param1.value == param2.value)        
     return is_same
 
 

--- a/tests/managers/parameter_manager_test.py
+++ b/tests/managers/parameter_manager_test.py
@@ -82,7 +82,7 @@ def test_load(qtbot, tmp_path):
     ptree.save_settings_slot(file_path)
 
     parameter_copy = Parameter.create(name='settings', type='group', children=ParameterEx.params)
-    assert compareValuesParameter(ptree.settings, parameter_copy)
+    assert compareValuesParameter(ptree.settings, parameter_copy, with_self=False)
 
     parameters = iter_children_params(ptree.settings, childlist=[])
     parameters_copy = iter_children_params(parameter_copy, childlist=[])
@@ -99,7 +99,7 @@ def test_load(qtbot, tmp_path):
             elif 'tabular_table' == parameter.opts['type']:
                 parameter.setValue(TableModel([[0.5, 0.2, 0.6]], ['value20', 'val2', '555']))
 
-    assert not compareValuesParameter(ptree.settings, parameter_copy)
+    assert not compareValuesParameter(ptree.settings, parameter_copy, with_self=False)
     assert compareStructureParameter(ptree.settings, parameter_copy)
 
     ptree.update_settings_slot(file_path)
@@ -109,7 +109,7 @@ def test_load(qtbot, tmp_path):
         if parameter.value() != pcopy.value():
             print(parameter)
 
-    assert compareValuesParameter(ptree.settings, parameter_copy)
+    assert compareValuesParameter(ptree.settings, parameter_copy, with_self=False)
     assert compareStructureParameter(ptree.settings, parameter_copy)
 
     ptree.settings_tree.close()

--- a/tests/parameter_test/param_utils_test.py
+++ b/tests/parameter_test/param_utils_test.py
@@ -53,10 +53,13 @@ params4 = [
                 [{'title': 'Standard int:', 'name': 'aint', 'type': 'int', 'value': 20,}]},
     ]},
 ]    
+
 P1 = Parameter(name='settings1', type='group', children=params1)
 P2 = Parameter(name='settings2', type='group', children=params2)
 P3 = Parameter(name='settings3', type='group', children=params3)
 P4 = Parameter(name='settings4', type='group', children=params4)
+P1_bool = Parameter(name='settings1', type='bool', children=params1)
+P1_noedit = Parameter(name='settings1', type='group', children=params1, editable=False)
 
 def test_iter_children_params():
     settings = Parameter.create(name='settings', type='group', children=params)
@@ -144,7 +147,13 @@ def test_compareParameters():
     assert [putils.compareParameters(param1=P1,param2=P1) == True,
             putils.compareParameters(param1=P1,param2=P2) == False,
             putils.compareParameters(param1=P1,param2=P3) == False,
-            putils.compareParameters(param1=P1,param2=P4) == False]        
+            putils.compareParameters(param1=P1,param2=P4) == False,        
+            putils.compareParameters(param1=P1,param2=P1_bool) == False,
+            putils.compareParameters(param1=P1,param2=P1_bool, with_self=False) == True,
+            putils.compareParameters(param1=P1,param2=P1_noedit) == False,
+            putils.compareParameters(param1=P1,param2=P1_noedit, with_self=False) == True]
+    
+
 def test_compareStructureParameter():  
     assert [putils.compareStructureParameter(param1=P1,param2=P1) == True,
             putils.compareStructureParameter(param1=P1,param2=P2) == True,
@@ -155,7 +164,9 @@ def test_compareValuesParameter():
     assert [putils.compareValuesParameter(param1=P1,param2=P1) == True,
             putils.compareValuesParameter(param1=P1,param2=P2) == True,
             putils.compareValuesParameter(param1=P1,param2=P3) == False,
-            putils.compareValuesParameter(param1=P1,param2=P4) == False]
+            putils.compareValuesParameter(param1=P1,param2=P4) == False,
+            putils.compareValuesParameter(param1=P1,param2=P1_bool) == False,
+            putils.compareValuesParameter(param1=P1,param2=P1_bool, with_self=False) == True]
 
 
 class TestScroll:

--- a/tests/parameter_test/param_utils_test.py
+++ b/tests/parameter_test/param_utils_test.py
@@ -251,6 +251,6 @@ def test_ParameterWithPath_serialize():
     param_back: putils.ParameterWithPath = putils.ser_factory.get_apply_deserializer(
         putils.ser_factory.get_apply_serializer(p1_with_path))
     assert param_back.path == p1_with_path.path
-    assert putils.compareParameters(param_back.parameter, p1_with_path.parameter)
+    assert putils.compareParameters(param_back.parameter, p1_with_path.parameter, with_self=False)
     assert type(p1_with_path.parameter) == type(param_back.parameter)
 


### PR DESCRIPTION
PR related to #124

The compareStruct/compareValues do not consider the parent in the boolean output.
The reason for it was to follow the structure of the getValues from pyqtgraph in the getOpts/getStruct methods.

This PR adds the keyword with_self to the compareParameters/compareValuesParameter to take into account the opts/values of the parent parameter in the boolean output.

The default value of with_self is True which means that parent is considered as default behavior.